### PR TITLE
Hide variants in generated docs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -104,6 +104,7 @@ fn main() {
         writeln!(&mut file, "\n#[derive(Clone, Copy, Hash, Eq, PartialEq)]").unwrap();
         writeln!(&mut file, "pub enum Language {{").unwrap();
         for (num, &(ref id, _, _, _)) in codes.iter().enumerate() {
+            writeln!(&mut file, "    #[doc(hidden)]").unwrap();
             writeln!(&mut file, "    {} = {},", title(id), num).unwrap();
         }
         writeln!(&mut file, "}}\n\n").unwrap();


### PR DESCRIPTION
Hi :)

I really like this project, it makes handling different languages in my application a piece of cake :)

I have two(/three) open issues with this project however. The first one is that the documentation on [docs.rs](https://docs.rs) suffers a bit from the very long `enum Language` definition.

I have prepared a pull request to fix this. I hope you like it :)