### PR TITLE
Add `Debug` and `Serialize` traits to `Language`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ matrix:
 script:
   - cargo build --verbose --all
   - cargo build --verbose --all --features serde_serialize
-  - cargo test --verbose --all
+  - cargo test --verbose --all --features serde_serialize

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
+
+script:
+  - cargo build --verbose --all
+  - cargo build --verbose --all --features serde_serialize
+  - cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,13 @@ phf = "0.7.21"
 
 [dependencies.serde]
 optional = true
-version = "1.0.21"
-
-[dependencies.serde_derive]
-optional = true
-version = "1.0.21"
+version = "1.0"
 
 [features]
 default = []
 serde_serialize = [
     "serde",
-    "serde_derive",
 ]
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,35 @@
 [package]
-name = "isolang"
-version = "0.1.1"
+authors = ["Sebastian Humenda <shumenda@gmx.de>"]
+build = "build.rs"
 description = "Efficient, static lookup table for ISO 639 language codes"
 documentation = "https://docs.rs/isolang"
-authors = ["Sebastian Humenda <shumenda@gmx.de>"]
-repository = "https://github.com/humenda/isolang-rs"
-build = "build.rs"
-readme = "README.md"
-keywords = ["iso", "language"]
+keywords = [
+    "iso",
+    "language",
+]
 license = "Apache-1.0"
+name = "isolang"
+readme = "README.md"
+repository = "https://github.com/humenda/isolang-rs"
+version = "0.2.0"
+
+[build-dependencies]
+phf_codegen = "0.7.21"
 
 [dependencies]
 phf = "0.7.21"
 
-[build-dependencies]
-phf_codegen = "0.7.21"
+[dependencies.serde]
+optional = true
+version = "1.0.21"
+
+[dependencies.serde_derive]
+optional = true
+version = "1.0.21"
+
+[features]
+default = []
+serde_serialize = [
+    "serde",
+    "serde_derive",
+]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-ISO 639 language codes
-======================
+# ISO 639 language codes
 
 [![Build Status](https://travis-ci.org/humenda/isolang-rs.svg?branch=master)](https://travis-ci.org/humenda/isolang-rs) ·
 [Documentation](https://docs.rs/isolang)
 
-Introduction
-------------
-
+## Introduction
 
 When dealing with different language inputs and APIs, different standards are used to identify
 a language. Converting between these in an automated way can be tedious. This crate provides an
@@ -24,16 +21,16 @@ the details.
 
 ## Use
 
-Cargo.toml:
+`Cargo.toml`:
 
-```
+```toml
 [dependencies]
-isolang = "0.1"
+isolang = "0.2"
 ```
 
 ## Example
 
-```
+```rust
 use isolang::Language;
 
 assert_eq!(Language::from_639_1("de").unwrap().to_name(), "German");

--- a/README.md
+++ b/README.md
@@ -37,4 +37,12 @@ assert_eq!(Language::from_639_1("de").unwrap().to_name(), "German");
 assert_eq!(Language::from_639_3("spa").unwrap().to_639_1(), Some("es"));
 ```
 
+## Serde support
 
+This crate also supports serializing the `Language` enum. To enable this please add the following lines to your `Cargo.toml` (instead of the above code):
+
+```toml
+[dependencies.isolang]
+features = ["serde_serialize"]
+version = "0.2"
+```

--- a/build.rs
+++ b/build.rs
@@ -121,14 +121,7 @@ fn main() {
         write_overview_table(&mut file, &codes);
 
         // write enum with 639-3 codes (num is the index into the overview table)
-        writeln!(
-            &mut file,
-            "\n#[cfg_attr(feature=\"serde_serialize\", derive(Serialize))]"
-        ).unwrap();
-        writeln!(
-            &mut file,
-            "#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]"
-        ).unwrap();
+        writeln!(&mut file, "#[derive(Clone, Copy, Hash, Eq, PartialEq)]").unwrap();
         writeln!(&mut file, "pub enum Language {{").unwrap();
         for (num, &(ref id, _, _, _)) in codes.iter().enumerate() {
             writeln!(&mut file, "    {} = {},", title(id), num).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -123,7 +123,11 @@ fn main() {
         // write enum with 639-3 codes (num is the index into the overview table)
         writeln!(
             &mut file,
-            "\n#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]"
+            "\n#[cfg_attr(feature=\"serde_serialize\", derive(Serialize))]"
+        ).unwrap();
+        writeln!(
+            &mut file,
+            "#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]"
         ).unwrap();
         writeln!(&mut file, "pub enum Language {{").unwrap();
         for (num, &(ref id, _, _, _)) in codes.iter().enumerate() {

--- a/build.rs
+++ b/build.rs
@@ -121,7 +121,10 @@ fn main() {
         write_overview_table(&mut file, &codes);
 
         // write enum with 639-3 codes (num is the index into the overview table)
-        writeln!(&mut file, "\n#[derive(Clone, Copy, Hash, Eq, PartialEq)]").unwrap();
+        writeln!(
+            &mut file,
+            "\n#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]"
+        ).unwrap();
         writeln!(&mut file, "pub enum Language {{").unwrap();
         for (num, &(ref id, _, _, _)) in codes.iter().enumerate() {
             writeln!(&mut file, "    {} = {},", title(id), num).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,13 @@
 //! assert_eq!(Language::from_639_3("spa").unwrap().to_639_1(), Some("es"));
 //! ```
 
+#[cfg(feature = "serde_serialize")]
+#[macro_use]
+extern crate serde_derive;
+
+#[cfg(feature = "serde_serialize")]
+extern crate serde;
+
 extern crate phf;
 
 use std::str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,7 @@ impl Language {
     pub fn to_639_3(&self) -> &'static str {
         // It's safe to do so, we have written that by hadn as UTF-8 into the binary and if you
         // haven't changed the binary, it's UTF-8
-        unsafe {
-            str::from_utf8_unchecked(&OVERVIEW[*self as usize].0)
-        }
+        unsafe { str::from_utf8_unchecked(&OVERVIEW[*self as usize].0) }
     }
 
     /// Create two-letter ISO 639-1 representation of the language.
@@ -58,8 +56,11 @@ impl Language {
     /// assert!(Language::Gha.to_639_1().is_none());
     /// ```
     pub fn to_639_1(&self) -> Option<&'static str> {
-        unsafe { // Is safe, see `to_639_3()` for more details
-            OVERVIEW[*self as usize].1.map(|ref s| str::from_utf8_unchecked(*s))
+        unsafe {
+            // Is safe, see `to_639_3()` for more details
+            OVERVIEW[*self as usize]
+                .1
+                .map(|ref s| str::from_utf8_unchecked(*s))
         }
     }
 
@@ -80,7 +81,8 @@ impl Language {
     /// assert_eq!(Language::Swh.to_name(), "Swahili");
     /// ```
     pub fn to_name(&self) -> &'static str {
-        unsafe { // Is safe, see `to_639_3()` for more details
+        unsafe {
+            // Is safe, see `to_639_3()` for more details
             str::from_utf8_unchecked(OVERVIEW[*self as usize].2)
         }
     }
@@ -169,4 +171,3 @@ mod tests {
         assert!(Language::from_locale("en_GB.UTF-8").unwrap() == Language::Eng);
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,16 +19,14 @@
 //! ```
 
 #[cfg(feature = "serde_serialize")]
-#[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 #[cfg(feature = "serde_serialize")]
-extern crate serde;
+mod serde_impl;
 
 extern crate phf;
 
 use std::str;
-
 
 include!(concat!(env!("OUT_DIR"), "/isotable.rs"));
 
@@ -163,6 +161,7 @@ impl Language {
 #[cfg(test)]
 mod tests {
     use super::*;
+    extern crate serde_json;
 
     #[test]
     fn invalid_locale_gives_none() {
@@ -176,5 +175,20 @@ mod tests {
     fn test_valid_locales_are_correctly_decoded() {
         assert!(Language::from_locale("de_DE.UTF-8").unwrap() == Language::Deu);
         assert!(Language::from_locale("en_GB.UTF-8").unwrap() == Language::Eng);
+    }
+
+    #[test]
+    #[cfg(feature = "serde_serialize")]
+    fn test_serde() {
+        assert!(serde_json::to_string(&Language::Deu).unwrap() == String::from("\"deu\""));
+        assert!(serde_json::from_str::<Language>("\"deu\"").unwrap() == Language::Deu);
+
+        assert!(serde_json::from_str::<Language>("\"foo\"").is_err());
+    }
+}
+
+impl std::fmt::Debug for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_639_3())
     }
 }

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,0 +1,53 @@
+use ::*;
+
+impl serde::ser::Serialize for Language {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        s.serialize_str(self.to_639_3())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LanguageVisitor;
+
+impl<'a> serde::de::Visitor<'a> for LanguageVisitor {
+    type Value = Language;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a borrowed str")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match Language::from_639_3(v) {
+            Some(l) => Ok(l),
+            None => Err(serde::de::Error::unknown_variant(
+                v,
+                &["Any valid ISO 639-1 Code."],
+            )),
+        }
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'a [u8]) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_borrowed_str(str::from_utf8(v).map_err(|_| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Bytes(v), &self)
+        })?)
+    }
+}
+
+#[cfg(feature = "serde_serialize")]
+impl<'de> serde::de::Deserialize<'de> for Language {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(LanguageVisitor)
+    }
+}


### PR DESCRIPTION
Hi :)

I have also added the `Debug` trait to Language and *optional* support for `serde`s `Serialize` trait.

Would this be in line with your plans for the crate?

PS: The diff is so large mainly because there is also a `cargo fmt` commit and a reformatting of `Cargo.toml`.