### PR TITLE
Deserialize both ISO 639-3 and 639-1 codes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ mod tests {
     fn test_serde() {
         assert!(serde_json::to_string(&Language::Deu).unwrap() == String::from("\"deu\""));
         assert!(serde_json::from_str::<Language>("\"deu\"").unwrap() == Language::Deu);
+        assert!(serde_json::from_str::<Language>("\"fr\"").unwrap() == Language::Fra);
 
         assert!(serde_json::from_str::<Language>("\"foo\"").is_err());
     }

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -19,11 +19,11 @@ impl<'a> serde::de::Visitor<'a> for LanguageVisitor {
 
     fn visit_borrowed_str<E>(self, v: &'a str) -> Result<Self::Value, E>
             where E: serde::de::Error {
-        match Language::from_639_3(v) {
+        match Language::from_639_3(v).or_else(|| Language::from_639_1(v)) {
             Some(l) => Ok(l),
             None => Err(serde::de::Error::unknown_variant(
                 v,
-                &["Any valid ISO 639-1 Code."],
+                &["Any valid ISO 639-1 or 639-3 Code."],
             )),
         }
     }


### PR DESCRIPTION
Fixes #7. We fix the `serde` deserialization code and the error message to both support ISO 639-1 and 639-3 codes.