### PR TITLE
Implement trait Default using Undetermined iso language code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,11 @@ impl Language {
     }
 }
 
+impl Default for Language {
+    fn default() -> Self {
+        Language::Und
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -200,6 +205,11 @@ mod tests {
         let mut t = String::new();
         write!(t, "{:?}", Language::Eng).unwrap();
         assert!(String::from("eng") == t);
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(Language::default(), Language::Und);
     }
 
     #[test]


### PR DESCRIPTION
Hello,

Would you accept a pull request which implements the trait `std::default::Default` for `Language`, using the `und ` (undetermined) special language code as default value, please ?

Such special code is part of the iso 639 specification and looks a perfect candidate for a default value.

Such change should not have any impact on crates using isolang, but greatly simplify the life of developers which only options are to use a newtype for Language or implement Default on each type using Language.

Thank you very much in advance !
Cheers.