### PR TITLE
implement PartialOrd and OrdOrdering

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -171,7 +171,7 @@ fn main() {
         write_overview_table(&mut file, &codes);
 
         // write enum with 639-3 codes (num is the index into the overview table)
-        writeln!(&mut file, "#[derive(Clone, Copy, Hash, Eq, PartialEq)]").unwrap();
+        writeln!(&mut file, "#[derive(Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]").unwrap();
         writeln!(&mut file, "pub enum Language {{").unwrap();
         for (num, &(ref id, _, _, _)) in codes.iter().enumerate() {
             writeln!(&mut file, "    #[doc(hidden)]").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,4 +339,11 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_ordering() {
+        assert!(Language::Deu < Language::Fra);
+        let fra = Language::Fra;
+        assert!(fra <= Language::Fra);
+    }
 }


### PR DESCRIPTION
Hello,

Would you consider merging this PR which adds `PartialOrd` and `Ord` to `Language`, following the enum ordering (alphabetical ordering), please ?

Thank you very much in advance !
