### PR TITLE
Change Cargo.toml license to be consistent with LICENSE.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [
     "language-code",
     "autonym"
 ]
-license = "Apache-1.0"
+license = "Apache-2.0"
 name = "isolang"
 readme = "README.md"
 repository = "https://github.com/humenda/isolang-rs"


### PR DESCRIPTION
Both LICENSE.md and README.md state that the license is Apache-2.0,
which is GPL-compatible, while Cargo.toml shows the license to be
Apache-1.0, which is not GPL-compatible because of its advertising
clause and restrictions on using Apache-related names