### PR TITLE
Use implicit serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,6 @@ version = "1.0"
 default = ["english_names"]
 english_names = []
 local_names = []
-serde_serialize = [
-    "serde",
-]
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ add the following lines to your `Cargo.toml` (instead of the above code):
 
 ```toml
 [dependencies.isolang]
-features = ["serde_serialize"]
+features = ["serde"]
 version = "1.0"
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,7 @@
 //! assert_eq!(Language::from_639_3("spa").unwrap().to_639_1(), Some("es"));
 //! ```
 
-#[cfg(feature = "serde_serialize")]
-extern crate serde;
-
-#[cfg(feature = "serde_serialize")]
+#[cfg(feature = "serde")]
 mod serde_impl;
 
 extern crate phf;
@@ -228,7 +225,7 @@ impl std::fmt::Display for Language {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "serde_serialize")]
+    #[cfg(feature = "serde")]
     extern crate serde_json;
     use std::fmt::Write;
 
@@ -280,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde_serialize")]
+    #[cfg(feature = "serde")]
     fn test_serde() {
         assert!(serde_json::to_string(&Language::Deu).unwrap() == String::from("\"deu\""));
         assert!(serde_json::from_str::<Language>("\"deu\"").unwrap() == Language::Deu);

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -44,7 +44,6 @@ impl<'a> serde::de::Visitor<'a> for LanguageVisitor {
     }
 }
 
-#[cfg(feature = "serde_serialize")]
 impl<'de> serde::de::Deserialize<'de> for Language {
     fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_str(LanguageVisitor)


### PR DESCRIPTION
Optional dependencies can implicitly be used as features, and the `serde` name is pretty standard for this across the crates ecosystem, so would be nice to do it like this.