### PR TITLE
 Update ISO 639 and autonym table

### DIFF
--- a/iso-639-3.tab
+++ b/iso-639-3.tab
@@ -1,9 +1,9 @@
-Id	Part2B	Part2T	Part1	Scope	Language_Type	Ref_Name	Comment
+﻿Id	Part2B	Part2T	Part1	Scope	Language_Type	Ref_Name	Comment
 aaa				I	L	Ghotuo	
 aab				I	L	Alumu-Tesu	
 aac				I	L	Ari	
 aad				I	L	Amal	
-aae				I	L	Arbëreshë Albanian	
+aae			sq	I	L	Arbëreshë Albanian	
 aaf				I	L	Aranadan	
 aag				I	L	Ambrak	
 aah				I	L	Abu' Arapesh	
@@ -11,12 +11,12 @@ aai				I	L	Arifama-Miniafia
 aak				I	L	Ankave	
 aal				I	L	Afade	
 aan				I	L	Anambé	
-aao				I	L	Algerian Saharan Arabic	
+aao			ar	I	L	Algerian Saharan Arabic	
 aap				I	L	Pará Arára	
 aaq				I	E	Eastern Abnaki	
 aar	aar	aar	aa	I	L	Afar	
 aas				I	L	Aasáx	
-aat				I	L	Arvanitika Albanian	
+aat			sq	I	L	Arvanitika Albanian	
 aau				I	L	Abau	
 aaw				I	L	Solong	
 aax				I	L	Mandobo Atas	
@@ -28,7 +28,7 @@ abd				I	L	Manide
 abe				I	L	Western Abnaki	
 abf				I	L	Abai Sungai	
 abg				I	L	Abaga	
-abh				I	L	Tajiki Arabic	
+abh			ar	I	L	Tajiki Arabic	
 abi				I	L	Abidji	
 abj				I	E	Aka-Bea	
 abk	abk	abk	ab	I	L	Abkhazian	
@@ -42,7 +42,7 @@ abr				I	L	Abron
 abs				I	L	Ambonese Malay	
 abt				I	L	Ambulas	
 abu				I	L	Abure	
-abv				I	L	Baharna Arabic	
+abv			ar	I	L	Baharna Arabic	
 abw				I	L	Pal	
 abx				I	L	Inabaknon	
 aby				I	L	Aneme Wake	
@@ -56,24 +56,24 @@ ach	ach	ach		I	L	Acoli
 aci				I	E	Aka-Cari	
 ack				I	E	Aka-Kora	
 acl				I	E	Akar-Bale	
-acm				I	L	Mesopotamian Arabic	
+acm			ar	I	L	Mesopotamian Arabic	
 acn				I	L	Achang	
 acp				I	L	Eastern Acipa	
-acq				I	L	Ta'izzi-Adeni Arabic	
+acq			ar	I	L	Ta'izzi-Adeni Arabic	
 acr				I	L	Achi	
 acs				I	E	Acroá	
 act				I	L	Achterhoeks	
 acu				I	L	Achuar-Shiwiar	
 acv				I	L	Achumawi	
-acw				I	L	Hijazi Arabic	
-acx				I	L	Omani Arabic	
-acy				I	L	Cypriot Arabic	
+acw			ar	I	L	Hijazi Arabic	
+acx			ar	I	L	Omani Arabic	
+acy			ar	I	L	Cypriot Arabic	
 acz				I	L	Acheron	
 ada	ada	ada		I	L	Adangme	
 adb				I	L	Atauran	
 add				I	L	Lidzonka	
 ade				I	L	Adele	
-adf				I	L	Dhofari Arabic	
+adf			ar	I	L	Dhofari Arabic	
 adg				I	L	Andegerebinha	
 adh				I	L	Adhola	
 adi				I	L	Adi	
@@ -91,8 +91,8 @@ adx				I	L	Amdo Tibetan
 ady	ady	ady		I	L	Adyghe	
 adz				I	L	Adzera	
 aea				I	E	Areba	
-aeb				I	L	Tunisian Arabic	
-aec				I	L	Saidi Arabic	
+aeb			ar	I	L	Tunisian Arabic	
+aec			ar	I	L	Saidi Arabic	
 aed				I	L	Argentine Sign Language	
 aee				I	L	Northeast Pashai	
 aek				I	L	Haeke	
@@ -106,7 +106,7 @@ aeu				I	L	Akeu
 aew				I	L	Ambakich	
 aey				I	L	Amele	
 aez				I	L	Aeka	
-afb				I	L	Gulf Arabic	
+afb			ar	I	L	Gulf Arabic	
 afd				I	L	Andai	
 afe				I	L	Putukwam	
 afg				I	L	Afghan Sign Language	
@@ -227,12 +227,12 @@ alj				I	L	Alangan
 alk				I	L	Alak	
 all				I	L	Allar	
 alm				I	L	Amblong	
-aln				I	L	Gheg Albanian	
+aln			sq	I	L	Gheg Albanian	
 alo				I	L	Larike-Wakasihu	
 alp				I	L	Alune	
 alq				I	L	Algonquin	
 alr				I	L	Alutor	
-als				I	L	Tosk Albanian	
+als			sq	I	L	Tosk Albanian	
 alt	alt	alt		I	L	Southern Altai	
 alu				I	L	'Are'are	
 alw				I	L	Alaba-K’abeena	
@@ -310,8 +310,8 @@ aou				I	L	A'ou
 aox				I	L	Atorada	
 aoz				I	L	Uab Meto	
 apb				I	L	Sa'a	
-apc				I	L	North Levantine Arabic	
-apd				I	L	Sudanese Arabic	
+apc			ar	I	L	North Levantine Arabic	
+apd			ar	I	L	Sudanese Arabic	
 ape				I	L	Bukiyip	
 apf				I	L	Pahanan Agta	
 apg				I	L	Ampanang	
@@ -345,7 +345,7 @@ aqr				I	L	Arhâ
 aqt				I	L	Angaité	
 aqz				I	L	Akuntsu	
 ara	ara	ara	ar	M	L	Arabic	
-arb				I	L	Standard Arabic	
+arb			ar	I	L	Standard Arabic	
 arc	arc	arc		I	A	Official Aramaic (700-300 BCE)	
 ard				I	E	Arabana	
 are				I	L	Western Arrarnta	
@@ -358,15 +358,15 @@ arl				I	L	Arabela
 arn	arn	arn		I	L	Mapudungun	
 aro				I	L	Araona	
 arp	arp	arp		I	L	Arapaho	
-arq				I	L	Algerian Arabic	
+arq			ar	I	L	Algerian Arabic	
 arr				I	L	Karo (Brazil)	
-ars				I	L	Najdi Arabic	
+ars			ar	I	L	Najdi Arabic	
 aru				I	E	Aruá (Amazonas State)	
 arv				I	L	Arbore	
 arw	arw	arw		I	L	Arawak	
 arx				I	L	Aruá (Rodonia State)	
-ary				I	L	Moroccan Arabic	
-arz				I	L	Egyptian Arabic	
+ary			ar	I	L	Moroccan Arabic	
+arz			ar	I	L	Egyptian Arabic	
 asa				I	L	Asu (Tanzania)	
 asb				I	L	Assiniboine	
 asc				I	L	Casuarina Coast Asmat	
@@ -437,14 +437,14 @@ auu				I	L	Auye
 auw				I	L	Awyi	
 aux				I	E	Aurá	
 auy				I	L	Awiyaana	
-auz				I	L	Uzbeki Arabic	
+auz			ar	I	L	Uzbeki Arabic	
 ava	ava	ava	av	I	L	Avaric	
 avb				I	L	Avau	
 avd				I	L	Alviri-Vidari	
 ave	ave	ave	ae	I	A	Avestan	
 avi				I	L	Avikam	
 avk				I	C	Kotava	
-avl				I	L	Eastern Egyptian Bedawi Arabic	
+avl			ar	I	L	Eastern Egyptian Bedawi Arabic	
 avm				I	E	Angkamuthi	
 avn				I	L	Avatime	
 avo				I	E	Agavotaguerra	
@@ -480,30 +480,30 @@ axm				I	H	Middle Armenian
 axx				I	L	Xârâgurè	
 aya				I	L	Awar	
 ayb				I	L	Ayizo Gbe	
-ayc				I	L	Southern Aymara	
+ayc			ay	I	L	Southern Aymara	
 ayd				I	E	Ayabadhu	
 aye				I	L	Ayere	
 ayg				I	L	Ginyanga	
-ayh				I	L	Hadrami Arabic	
+ayh			ar	I	L	Hadrami Arabic	
 ayi				I	L	Leyigha	
 ayk				I	L	Akuku	
-ayl				I	L	Libyan Arabic	
+ayl			ar	I	L	Libyan Arabic	
 aym	aym	aym	ay	M	L	Aymara	
-ayn				I	L	Sanaani Arabic	
+ayn			ar	I	L	Sanaani Arabic	
 ayo				I	L	Ayoreo	
-ayp				I	L	North Mesopotamian Arabic	
+ayp			ar	I	L	North Mesopotamian Arabic	
 ayq				I	L	Ayi (Papua New Guinea)	
-ayr				I	L	Central Aymara	
+ayr			ay	I	L	Central Aymara	
 ays				I	L	Sorsogon Ayta	
 ayt				I	L	Magbukun Ayta	
 ayu				I	L	Ayu	
 ayz				I	L	Mai Brat	
 aza				I	L	Azha	
-azb				I	L	South Azerbaijani	
+azb			az	I	L	South Azerbaijani	
 azd				I	L	Eastern Durango Nahuatl	
 aze	aze	aze	az	M	L	Azerbaijani	
 azg				I	L	San Pedro Amuzgos Amuzgo	
-azj				I	L	North Azerbaijani	
+azj			az	I	L	North Azerbaijani	
 azm				I	L	Ipalapa Amuzgo	
 azn				I	L	Western Durango Nahuatl	
 azo				I	L	Awing	
@@ -696,7 +696,7 @@ bhn				I	L	Bohtan Neo-Aramaic
 bho	bho	bho		I	L	Bhojpuri	
 bhp				I	L	Bima	
 bhq				I	L	Tukang Besi South	
-bhr				I	L	Bara Malagasy	
+bhr			mg	I	L	Bara Malagasy	
 bhs				I	L	Buwal	
 bht				I	L	Bhattiyali	
 bhu				I	L	Bhunjia	
@@ -739,7 +739,7 @@ bjj				I	L	Kanauji
 bjk				I	L	Barok	
 bjl				I	L	Bulu (Papua New Guinea)	
 bjm				I	L	Bajelani	
-bjn				I	L	Banjar	
+bjn			ms	I	L	Banjar	
 bjo				I	L	Mid-Southern Banda	
 bjp				I	L	Fanamaket	
 bjr				I	L	Binumarien	
@@ -811,7 +811,7 @@ bmi				I	L	Bagirmi
 bmj				I	L	Bote-Majhi	
 bmk				I	L	Ghayavi	
 bml				I	L	Bomboli	
-bmm				I	L	Northern Betsimisaraka Malagasy	
+bmm			mg	I	L	Northern Betsimisaraka Malagasy	
 bmn				I	E	Bina (Papua New Guinea)	
 bmo				I	L	Bambalang	
 bmp				I	L	Bulgebi	
@@ -980,7 +980,7 @@ btf				I	L	Birgit
 btg				I	L	Gagnoa Bété	
 bth				I	L	Biatah Bidayuh	
 bti				I	L	Burate	
-btj				I	L	Bacanese Malay	
+btj			ms	I	L	Bacanese Malay	
 btm				I	L	Batak Mandailing	
 btn				I	L	Ratagnon	
 bto				I	L	Rinconada Bikol	
@@ -1024,7 +1024,7 @@ bva				I	L	Barein
 bvb				I	L	Bube	
 bvc				I	L	Baelelea	
 bvd				I	L	Baeggu	
-bve				I	L	Berau Malay	
+bve			ms	I	L	Berau Malay	
 bvf				I	L	Boor	
 bvg				I	L	Bonkeng	
 bvh				I	L	Bure	
@@ -1039,7 +1039,7 @@ bvp				I	L	Bumang
 bvq				I	L	Birri	
 bvr				I	L	Burarra	
 bvt				I	L	Bati (Indonesia)	
-bvu				I	L	Bukit Malay	
+bvu			ms	I	L	Bukit Malay	
 bvv				I	E	Baniva	
 bvw				I	L	Boga	
 bvx				I	L	Dibole	
@@ -1119,7 +1119,7 @@ byx				I	L	Qaqet
 byz				I	L	Banaro	
 bza				I	L	Bandi	
 bzb				I	L	Andio	
-bzc				I	L	Southern Betsimisaraka Malagasy	
+bzc			mg	I	L	Southern Betsimisaraka Malagasy	
 bzd				I	L	Bribri	
 bze				I	L	Jenaama Bozo	
 bzf				I	L	Boikin	
@@ -1204,7 +1204,7 @@ cdi				I	L	Chodri
 cdj				I	L	Churahi	
 cdm				I	L	Chepang	
 cdn				I	L	Chaudangsi	
-cdo				I	L	Min Dong Chinese	
+cdo			zh	I	L	Min Dong Chinese	
 cdr				I	L	Cinda-Regi-Tiyal	
 cds				I	L	Chadian Sign Language	
 cdy				I	L	Chadong	
@@ -1260,7 +1260,7 @@ cim				I	L	Cimbrian
 cin				I	L	Cinta Larga	
 cip				I	L	Chiapanec	
 cir				I	L	Tiri	
-ciw				I	L	Chippewa	
+ciw			oj	I	L	Chippewa	
 ciy				I	L	Chaima	
 cja				I	L	Western Cham	
 cje				I	L	Chru	
@@ -1273,8 +1273,8 @@ cjo				I	L	Ashéninka Pajonal
 cjp				I	L	Cabécar	
 cjs				I	L	Shor	
 cjv				I	L	Chuave	
-cjy				I	L	Jinyu Chinese	
-ckb				I	L	Central Kurdish	
+cjy			zh	I	L	Jinyu Chinese	
+ckb			ku	I	L	Central Kurdish	
 ckh				I	L	Chak	
 ckl				I	L	Cibak	
 ckm				I	L	Chakavian	
@@ -1310,7 +1310,7 @@ cmg				I	H	Classical Mongolian
 cmi				I	L	Emberá-Chamí	
 cml				I	L	Campalagian	
 cmm				I	E	Michigamea	
-cmn				I	L	Mandarin Chinese	
+cmn			zh	I	L	Mandarin Chinese	
 cmo				I	L	Central Mnong	
 cmr				I	L	Mro-Khimi Chin	
 cms				I	A	Messapic	
@@ -1324,15 +1324,15 @@ cni				I	L	Asháninka
 cnk				I	L	Khumi Chin	
 cnl				I	L	Lalana Chinantec	
 cno				I	L	Con	
-cnp				I	L	Northern Ping Chinese	
+cnp			zh	I	L	Northern Ping Chinese	
 cnq				I	L	Chung	
-cnr	cnr	cnr		I	L	Montenegrin	
+cnr	cnr	cnr	sh	I	L	Montenegrin	
 cns				I	L	Central Asmat	
 cnt				I	L	Tepetotutla Chinantec	
 cnu				I	L	Chenoua	
 cnw				I	L	Ngawn Chin	
 cnx				I	H	Middle Cornish	
-coa				I	L	Cocos Islands Malay	
+coa			ms	I	L	Cocos Islands Malay	
 cob				I	E	Chicomuceltec	
 coc				I	L	Cocopa	
 cod				I	L	Cocama-Cocamilla	
@@ -1365,7 +1365,7 @@ cpn				I	L	Cherepon
 cpo				I	L	Kpeego	
 cps				I	L	Capiznon	
 cpu				I	L	Pichis Ashéninka	
-cpx				I	L	Pu-Xian Chinese	
+cpx			zh	I	L	Pu-Xian Chinese	
 cpy				I	L	South Ucayali Ashéninka	
 cqd				I	L	Chuanqiandian Cluster Miao	
 cra				I	L	Chara	
@@ -1377,10 +1377,10 @@ crf				I	E	Caramanta
 crg				I	L	Michif	
 crh	crh	crh		I	L	Crimean Tatar	
 cri				I	L	Sãotomense	
-crj				I	L	Southern East Cree	
-crk				I	L	Plains Cree	
-crl				I	L	Northern East Cree	
-crm				I	L	Moose Cree	
+crj			cr	I	L	Southern East Cree	
+crk			cr	I	L	Plains Cree	
+crl			cr	I	L	Northern East Cree	
+crm			cr	I	L	Moose Cree	
 crn				I	L	El Nayar Cora	
 cro				I	L	Crow	
 crq				I	L	Iyo'wujwa Chorote	
@@ -1407,13 +1407,13 @@ csl				I	L	Chinese Sign Language
 csm				I	L	Central Sierra Miwok	
 csn				I	L	Colombian Sign Language	
 cso				I	L	Sochiapam Chinantec	
-csp				I	L	Southern Ping Chinese	
+csp			zh	I	L	Southern Ping Chinese	
 csq				I	L	Croatia Sign Language	
 csr				I	L	Costa Rican Sign Language	
 css				I	E	Southern Ohlone	
 cst				I	L	Northern Ohlone	
 csv				I	L	Sumtu Chin	
-csw				I	L	Swampy Cree	
+csw			cr	I	L	Swampy Cree	
 csx				I	L	Cambodian Sign Language	
 csy				I	L	Siyin Chin	
 csz				I	L	Coos	
@@ -1455,7 +1455,7 @@ cvg				I	L	Chug
 cvn				I	L	Valle Nacional Chinantec	
 cwa				I	L	Kabwa	
 cwb				I	L	Maindo	
-cwd				I	L	Woods Cree	
+cwd			cr	I	L	Woods Cree	
 cwe				I	L	Kwere	
 cwg				I	L	Chewong	
 cwt				I	L	Kuwaataay	
@@ -1463,10 +1463,10 @@ cya				I	L	Nopala Chatino
 cyb				I	E	Cayubaba	
 cym	wel	cym	cy	I	L	Welsh	
 cyo				I	L	Cuyonon	
-czh				I	L	Huizhou Chinese	
+czh			zh	I	L	Huizhou Chinese	
 czk				I	E	Knaanic	
 czn				I	L	Zenzontepec Chatino	
-czo				I	L	Min Zhong Chinese	
+czo			zh	I	L	Min Zhong Chinese	
 czt				I	L	Zotung Chin	
 daa				I	L	Dangaléat	
 dac				I	L	Dambi	
@@ -1712,7 +1712,7 @@ dtr				I	L	Lotud
 dts				I	L	Toro So Dogon	
 dtt				I	L	Toro Tegu Dogon	
 dtu				I	L	Tebul Ure Dogon	
-dty				I	L	Dotyali	
+dty			ne	I	L	Dotyali	
 dua	dua	dua		I	L	Duala	
 dub				I	L	Dubli	
 duc				I	L	Duna	
@@ -1726,7 +1726,7 @@ dul				I	L	Alabat Island Agta
 dum	dum	dum		I	H	Middle Dutch (ca. 1050-1350)	
 dun				I	L	Dusun Deyah	
 duo				I	L	Dupaninan Agta	
-dup				I	L	Duano	
+dup			ms	I	L	Duano	
 duq				I	L	Dusun Malang	
 dur				I	L	Dii	
 dus				I	L	Dumi	
@@ -1790,7 +1790,7 @@ eka	eka	eka		I	L	Ekajuk
 eke				I	L	Ekit	
 ekg				I	L	Ekari	
 eki				I	L	Eki	
-ekk				I	L	Standard Estonian	
+ekk			et	I	L	Standard Estonian	
 ekl				I	L	Kol (Bangladesh)	
 ekm				I	L	Elip	
 eko				I	L	Koti	
@@ -1855,8 +1855,8 @@ erw				I	L	Erokwanas
 ese				I	L	Ese Ejja	
 esg				I	L	Aheri Gondi	
 esh				I	L	Eshtehardi	
-esi				I	L	North Alaskan Inupiatun	
-esk				I	L	Northwest Alaska Inupiatun	
+esi			ik	I	L	North Alaskan Inupiatun	
+esk			ik	I	L	Northwest Alaska Inupiatun	
 esl				I	L	Egypt Sign Language	
 esm				I	E	Esuma	
 esn				I	L	Salvadoran Sign Language	
@@ -1904,7 +1904,7 @@ fao	fao	fao	fo	I	L	Faroese
 fap				I	L	Paloor	
 far				I	L	Fataleka	
 fas	per	fas	fa	M	L	Persian	
-fat	fat	fat		I	L	Fanti	
+fat	fat	fat	ak	I	L	Fanti	
 fau				I	L	Fayu	
 fax				I	L	Fala	
 fay				I	L	Southwestern Fars	
@@ -1913,7 +1913,7 @@ fbl				I	L	West Albay Bikol
 fcs				I	L	Quebec Sign Language	
 fer				I	L	Feroge	
 ffi				I	L	Foia Foia	
-ffm				I	L	Maasina Fulfulde	
+ffm			ff	I	L	Maasina Fulfulde	
 fgr				I	L	Fongoro	
 fia				I	L	Nobiin	
 fie				I	L	Fyer	
@@ -1962,22 +1962,22 @@ fry	fry	fry	fy	I	L	Western Frisian
 fse				I	L	Finnish Sign Language	
 fsl				I	L	French Sign Language	
 fss				I	L	Finland-Swedish Sign Language	
-fub				I	L	Adamawa Fulfulde	
-fuc				I	L	Pulaar	
+fub			ff	I	L	Adamawa Fulfulde	
+fuc			ff	I	L	Pulaar	
 fud				I	L	East Futuna	
-fue				I	L	Borgu Fulfulde	
-fuf				I	L	Pular	
-fuh				I	L	Western Niger Fulfulde	
-fui				I	L	Bagirmi Fulfulde	
+fue			ff	I	L	Borgu Fulfulde	
+fuf			ff	I	L	Pular	
+fuh			ff	I	L	Western Niger Fulfulde	
+fui			ff	I	L	Bagirmi Fulfulde	
 fuj				I	L	Ko	
 ful	ful	ful	ff	M	L	Fulah	
 fum				I	L	Fum	
 fun				I	L	Fulniô	
-fuq				I	L	Central-Eastern Niger Fulfulde	
+fuq			ff	I	L	Central-Eastern Niger Fulfulde	
 fur	fur	fur		I	L	Friulian	
 fut				I	L	Futuna-Aniwa	
 fuu				I	L	Furu	
-fuv				I	L	Nigerian Fulfulde	
+fuv			ff	I	L	Nigerian Fulfulde	
 fuy				I	L	Fuyug	
 fvr				I	L	Fur	
 fwa				I	L	Fwâi	
@@ -1995,7 +1995,7 @@ gaj				I	L	Gadsup
 gak				I	L	Gamkonora	
 gal				I	L	Galolen	
 gam				I	L	Kandawo	
-gan				I	L	Gan Chinese	
+gan			zh	I	L	Gan Chinese	
 gao				I	L	Gants	
 gap				I	L	Gal	
 gaq				I	L	Gata'	
@@ -2004,9 +2004,9 @@ gas				I	L	Adiwasi Garasia
 gat				I	L	Kenati	
 gau				I	L	Mudhili Gadaba	
 gaw				I	L	Nobonob	
-gax				I	L	Borana-Arsi-Guji Oromo	
+gax			om	I	L	Borana-Arsi-Guji Oromo	
 gay	gay	gay		I	L	Gayo	
-gaz				I	L	West Central Oromo	
+gaz			om	I	L	West Central Oromo	
 gba	gba	gba		M	L	Gbaya (Central African Republic)	
 gbb				I	L	Kaytetye	
 gbd				I	L	Karajarri	
@@ -2182,7 +2182,7 @@ gnq				I	L	Gana
 gnr				I	E	Gureng Gureng	
 gnt				I	L	Guntai	
 gnu				I	L	Gnau	
-gnw				I	L	Western Bolivian Guaraní	
+gnw			gn	I	L	Western Bolivian Guaraní	
 gnz				I	L	Ganzi	
 goa				I	L	Guro	
 gob				I	L	Playero	
@@ -2256,14 +2256,14 @@ guc				I	L	Wayuu
 gud				I	L	Yocoboué Dida	
 gue				I	L	Gurindji	
 guf				I	L	Gupapuyngu	
-gug				I	L	Paraguayan Guaraní	
+gug			gn	I	L	Paraguayan Guaraní	
 guh				I	L	Guahibo	
-gui				I	L	Eastern Bolivian Guaraní	
+gui			gn	I	L	Eastern Bolivian Guaraní	
 guj	guj	guj	gu	I	L	Gujarati	
 guk				I	L	Gumuz	
 gul				I	L	Sea Island Creole English	
 gum				I	L	Guambiano	
-gun				I	L	Mbyá Guaraní	
+gun			gn	I	L	Mbyá Guaraní	
 guo				I	L	Guayabero	
 gup				I	L	Gunwinggu	
 guq				I	L	Aché	
@@ -2325,13 +2325,13 @@ haa				I	L	Han
 hab				I	L	Hanoi Sign Language	
 hac				I	L	Gurani	
 had				I	L	Hatam	
-hae				I	L	Eastern Oromo	
+hae			om	I	L	Eastern Oromo	
 haf				I	L	Haiphong Sign Language	
 hag				I	L	Hanga	
 hah				I	L	Hahon	
 hai	hai	hai		M	L	Haida	
 haj				I	L	Hajong	
-hak				I	L	Hakka Chinese	
+hak			zh	I	L	Hakka Chinese	
 hal				I	L	Halang	
 ham				I	L	Hewa	
 han				I	L	Hangaza	
@@ -2387,7 +2387,7 @@ hir				I	L	Himarimã
 hit	hit	hit		I	A	Hittite	
 hiw				I	L	Hiw	
 hix				I	L	Hixkaryána	
-hji				I	L	Haji	
+hji			ms	I	L	Haji	
 hka				I	L	Kahe	
 hke				I	L	Hunde	
 hkh				I	L	Khah	
@@ -2473,7 +2473,7 @@ hrz				I	L	Harzani
 hsb	hsb	hsb		I	L	Upper Sorbian	
 hsh				I	L	Hungarian Sign Language	
 hsl				I	L	Hausa Sign Language	
-hsn				I	L	Xiang Chinese	
+hsn			zh	I	L	Xiang Chinese	
 hss				I	L	Harsusi	
 hti				I	E	Hoti	
 hto				I	L	Minica Huitoto	
@@ -2575,7 +2575,7 @@ ije				I	L	Biseni
 ijj				I	L	Ede Ije	
 ijn				I	L	Kalabari	
 ijs				I	L	Southeast Ijo	
-ike				I	L	Eastern Canadian Inuktitut	
+ike			iu	I	L	Eastern Canadian Inuktitut	
 iki				I	L	Iko	
 ikk				I	L	Ika	
 ikl				I	L	Ikulu	
@@ -2583,7 +2583,7 @@ iko				I	L	Olulumo-Ikom
 ikp				I	L	Ikpeshi	
 ikr				I	E	Ikaranggal	
 iks				I	L	Inuit Sign Language	
-ikt				I	L	Inuinnaqtun	
+ikt			iu	I	L	Inuinnaqtun	
 iku	iku	iku	iu	M	L	Inuktitut	
 ikv				I	L	Iku-Gora-Ankwa	
 ikw				I	L	Ikwere	
@@ -2696,7 +2696,7 @@ jae				I	L	Yabem
 jaf				I	L	Jara	
 jah				I	L	Jah Hut	
 jaj				I	L	Zazao	
-jak				I	L	Jakun	
+jak			ms	I	L	Jakun	
 jal				I	L	Yalahatan	
 jam				I	L	Jamaican Creole English	
 jan				I	E	Jandai	
@@ -2706,7 +2706,7 @@ jas				I	L	New Caledonian Javanese
 jat				I	L	Jakati	
 jau				I	L	Yaur	
 jav	jav	jav	jv	I	L	Javanese	
-jax				I	L	Jambi Malay	
+jax			ms	I	L	Jambi Malay	
 jay				I	L	Yan-nhangu	
 jaz				I	L	Jawe	
 jbe				I	L	Judeo-Berber	
@@ -2874,7 +2874,7 @@ kbu				I	L	Kabutra
 kbv				I	L	Dera (Indonesia)	
 kbw				I	L	Kaiep	
 kbx				I	L	Ap Ma	
-kby				I	L	Manga Kanuri	
+kby			kr	I	L	Manga Kanuri	
 kbz				I	L	Duhwa	
 kca				I	L	Khanty	
 kcb				I	L	Kawacha	
@@ -3007,7 +3007,7 @@ khf				I	L	Khuen
 khg				I	L	Khams Tibetan	
 khh				I	L	Kehu	
 khj				I	L	Kuturmi	
-khk				I	L	Halh Mongolian	
+khk			mn	I	L	Halh Mongolian	
 khl				I	L	Lusi	
 khm	khm	khm	km	I	L	Khmer	
 khn				I	L	Khandesi	
@@ -3142,7 +3142,7 @@ kmn				I	L	Awtuw
 kmo				I	L	Kwoma	
 kmp				I	L	Gimme	
 kmq				I	L	Kwama	
-kmr				I	L	Northern Kurdish	
+kmr			ku	I	L	Northern Kurdish	
 kms				I	L	Kamasau	
 kmt				I	L	Kemtuik	
 kmu				I	L	Kanite	
@@ -3153,11 +3153,11 @@ kmy				I	L	Koma
 kmz				I	L	Khorasani Turkish	
 kna				I	L	Dera (Nigeria)	
 knb				I	L	Lubuagan Kalinga	
-knc				I	L	Central Kanuri	
+knc			kr	I	L	Central Kanuri	
 knd				I	L	Konda	
 kne				I	L	Kankanaey	
 knf				I	L	Mankanya	
-kng				I	L	Koongo	
+kng			kg	I	L	Koongo	
 kni				I	L	Kanufi	
 knj				I	L	Western Kanjobal	
 knk				I	L	Kuranko	
@@ -3183,7 +3183,7 @@ koe				I	L	Kacipo-Bale Suri
 kof				I	E	Kubi	
 kog				I	L	Cogui	
 koh				I	L	Koyo	
-koi				I	L	Komi-Permyak	
+koi			kv	I	L	Komi-Permyak	
 kok	kok	kok		M	L	Konkani (macrolanguage)	
 kol				I	L	Kol (Papua New Guinea)	
 kom	kom	kom	kv	M	L	Komi	
@@ -3219,7 +3219,7 @@ kpr				I	L	Korafe-Yegha
 kps				I	L	Tehit	
 kpt				I	L	Karata	
 kpu				I	L	Kafoa	
-kpv				I	L	Komi-Zyrian	
+kpv			kv	I	L	Komi-Zyrian	
 kpw				I	L	Kobon	
 kpx				I	L	Mountain Koiali	
 kpy				I	L	Koryak	
@@ -3265,7 +3265,7 @@ krn				I	L	Sapo
 krp				I	L	Korop	
 krr				I	L	Krung	
 krs				I	L	Gbaya (Sudan)	
-krt				I	L	Tumari Kanuri	
+krt			kr	I	L	Tumari Kanuri	
 kru	kru	kru		I	L	Kurukh	
 krv				I	L	Kavet	
 krw				I	L	Western Krahn	
@@ -3350,7 +3350,7 @@ kux				I	L	Kukatja
 kuy				I	L	Kuuku-Ya'u	
 kuz				I	E	Kunza	
 kva				I	L	Bagvalal	
-kvb				I	L	Kubu	
+kvb			ms	I	L	Kubu	
 kvc				I	L	Kove	
 kvd				I	L	Kui (Indonesia)	
 kve				I	L	Kalabakan	
@@ -3366,7 +3366,7 @@ kvn				I	L	Border Kuna
 kvo				I	L	Dobel	
 kvp				I	L	Kompane	
 kvq				I	L	Geba Karen	
-kvr				I	L	Kerinci	
+kvr			ms	I	L	Kerinci	
 kvt				I	L	Lahta Karen	
 kvu				I	L	Yinbaw Karen	
 kvv				I	L	Kola	
@@ -3397,12 +3397,12 @@ kwu				I	L	Kwakum
 kwv				I	L	Sara Kaba Náà	
 kww				I	L	Kwinti	
 kwx				I	L	Khirwar	
-kwy				I	L	San Salvador Kongo	
+kwy			kg	I	L	San Salvador Kongo	
 kwz				I	E	Kwadi	
 kxa				I	L	Kairiru	
 kxb				I	L	Krobu	
 kxc				I	L	Konso	
-kxd				I	L	Brunei	
+kxd			ms	I	L	Brunei	
 kxf				I	L	Manumanaw Karen	
 kxh				I	L	Karo (Ethiopia)	
 kxi				I	L	Keningau Murut	
@@ -3519,8 +3519,8 @@ lby				I	E	Lamalama
 lbz				I	L	Lardil	
 lcc				I	L	Legenyem	
 lcd				I	L	Lola	
-lce				I	L	Loncong	
-lcf				I	L	Lubu	
+lce			ms	I	L	Loncong	
+lcf			ms	I	L	Lubu	
 lch				I	L	Luchazi	
 lcl				I	L	Lisela	
 lcm				I	L	Tungag	
@@ -3532,7 +3532,7 @@ ldb				I	L	Dũya
 ldd				I	L	Luri	
 ldg				I	L	Lenyima	
 ldh				I	L	Lamja-Dengsa-Tola	
-ldi				I	L	Laari	
+ldi			kg	I	L	Laari	
 ldj				I	L	Lemoro	
 ldk				I	L	Leelau	
 ldl				I	L	Kaan	
@@ -3614,7 +3614,7 @@ lis				I	L	Lisu
 lit	lit	lit	lt	I	L	Lithuanian	
 liu				I	L	Logorik	
 liv				I	L	Liv	
-liw				I	L	Col	
+liw			ms	I	L	Col	
 lix				I	L	Liabuku	
 liy				I	L	Banda-Bambari	
 liz				I	L	Libinza	
@@ -3761,7 +3761,7 @@ lsv				I	L	Sivia Sign Language
 lsw				I	L	Seychelles Sign Language	
 lsy				I	L	Mauritian Sign Language	
 ltc				I	H	Late Middle Chinese	
-ltg				I	L	Latgalian	
+ltg			lv	I	L	Latgalian	
 lth				I	L	Thur	
 lti				I	L	Leti (Indonesia)	
 ltn				I	L	Latundê	
@@ -3796,7 +3796,7 @@ luz				I	L	Southern Luri
 lva				I	L	Maku'a	
 lvi				I	L	Lavi	
 lvk				I	L	Lavukaleve	
-lvs				I	L	Standard Latvian	
+lvs			lv	I	L	Standard Latvian	
 lvu				I	L	Levuka	
 lwa				I	L	Lwalu	
 lwe				I	L	Lewo Eleng	
@@ -3813,7 +3813,7 @@ lxm				I	L	Lakurumau
 lya				I	L	Layakha	
 lyg				I	L	Lyngngam	
 lyn				I	L	Luyana	
-lzh				I	H	Literary Chinese	
+lzh			zh	I	H	Literary Chinese	
 lzl				I	L	Litzlitz	
 lzn				I	L	Leinong Naga	
 lzz				I	L	Laz	
@@ -3837,7 +3837,7 @@ mat				I	L	San Francisco Matlatzinca
 mau				I	L	Huautla Mazatec	
 mav				I	L	Sateré-Mawé	
 maw				I	L	Mampruli	
-max				I	L	North Moluccan Malay	
+max			ms	I	L	North Moluccan Malay	
 maz				I	L	Central Mazahua	
 mba				I	L	Higaonon	
 mbb				I	L	Western Bukidnon Manobo	
@@ -3928,7 +3928,7 @@ mek				I	L	Mekeo
 mel				I	L	Central Melanau	
 mem				I	E	Mangala	
 men	men	men		I	L	Mende (Sierra Leone)	
-meo				I	L	Kedah Malay	
+meo			ms	I	L	Kedah Malay	
 mep				I	L	Miriwoong	
 meq				I	L	Merey	
 mer				I	L	Meru	
@@ -3939,8 +3939,8 @@ mev				I	L	Mano
 mew				I	L	Maaka	
 mey				I	L	Hassaniyya	
 mez				I	L	Menominee	
-mfa				I	L	Pattani Malay	
-mfb				I	L	Bangka	
+mfa			ms	I	L	Pattani Malay	
+mfb			ms	I	L	Bangka	
 mfc				I	L	Mba	
 mfd				I	L	Mendankwe-Nkwen	
 mfe				I	L	Morisyen	
@@ -4027,7 +4027,7 @@ mij				I	L	Abar
 mik				I	L	Mikasuki	
 mil				I	L	Peñoles Mixtec	
 mim				I	L	Alacatlatzala Mixtec	
-min	min	min		I	L	Minangkabau	
+min	min	min	ms	I	L	Minangkabau	
 mio				I	L	Pinotepa Nacional Mixtec	
 mip				I	L	Apasco-Apoala Mixtec	
 miq				I	L	Mískito	
@@ -4151,7 +4151,7 @@ mnk				I	L	Mandinka
 mnl				I	L	Tiale	
 mnm				I	L	Mapena	
 mnn				I	L	Southern Mnong	
-mnp				I	L	Min Bei Chinese	
+mnp			zh	I	L	Min Bei Chinese	
 mnq				I	L	Minriq	
 mnr				I	L	Mono (USA)	
 mns				I	L	Mansi	
@@ -4214,7 +4214,7 @@ mqb				I	L	Mbuko
 mqc				I	L	Mangole	
 mqe				I	L	Matepi	
 mqf				I	L	Momuna	
-mqg				I	L	Kota Bangun Kutai Malay	
+mqg			ms	I	L	Kota Bangun Kutai Malay	
 mqh				I	L	Tlazoyaltepec Mixtec	
 mqi				I	L	Mariri	
 mqj				I	L	Mamasa	
@@ -4267,8 +4267,8 @@ msd				I	L	Yucatec Maya Sign Language
 mse				I	L	Musey	
 msf				I	L	Mekwei	
 msg				I	L	Moraid	
-msh				I	L	Masikoro Malagasy	
-msi				I	L	Sabah Malay	
+msh			mg	I	L	Masikoro Malagasy	
+msi			ms	I	L	Sabah Malay	
 msj				I	L	Ma (Democratic Republic of Congo)	
 msk				I	L	Mansaka	
 msl				I	L	Molof	
@@ -4317,7 +4317,7 @@ mud				I	L	Mednyj Aleut
 mue				I	L	Media Lengua	
 mug				I	L	Musgu	
 muh				I	L	Mündü	
-mui				I	L	Musi	
+mui			ms	I	L	Musi	
 muj				I	L	Mabire	
 muk				I	L	Mugom	
 mul	mul	mul		S	S	Multiple languages	
@@ -4337,7 +4337,7 @@ mva				I	L	Manam
 mvb				I	E	Mattole	
 mvd				I	L	Mamboru	
 mve				I	L	Marwari (Pakistan)	
-mvf				I	L	Peripheral Mongolian	
+mvf			mn	I	L	Peripheral Mongolian	
 mvg				I	L	Yucuañe Mixtec	
 mvh				I	L	Mulgi	
 mvi				I	L	Miyako	
@@ -4460,7 +4460,7 @@ naj				I	L	Nalu
 nak				I	L	Nakanai	
 nal				I	L	Nalik	
 nam				I	L	Ngan'gityemerri	
-nan				I	L	Min Nan Chinese	
+nan			zh	I	L	Min Nan Chinese	
 nao				I	L	Naaba	
 nap	nap	nap		I	L	Neapolitan	
 naq				I	L	Khoekhoe	
@@ -4601,7 +4601,7 @@ ngz				I	L	Ngungwel
 nha				I	L	Nhanda	
 nhb				I	L	Beng	
 nhc				I	E	Tabasco Nahuatl	
-nhd				I	L	Chiripá	
+nhd			gn	I	L	Chiripá	
 nhe				I	L	Eastern Huasteca Nahuatl	
 nhf				I	L	Nhuwala	
 nhg				I	L	Tetelcingo Nahuatl	
@@ -4782,7 +4782,7 @@ npa				I	L	Nar Phu
 npb				I	L	Nupbikha	
 npg				I	L	Ponyo-Gongwang Naga	
 nph				I	L	Phom Naga	
-npi				I	L	Nepali (individual language)	
+npi			ne	I	L	Nepali (individual language)	
 npl				I	L	Southeastern Puebla Nahuatl	
 npn				I	L	Mondropolon	
 npo				I	L	Pochuri Naga	
@@ -4980,14 +4980,14 @@ ohu				I	H	Old Hungarian
 oia				I	L	Oirata	
 oie				I	L	Okolie	
 oin				I	L	Inebu One	
-ojb				I	L	Northwestern Ojibwa	
-ojc				I	L	Central Ojibwa	
-ojg				I	L	Eastern Ojibwa	
+ojb			oj	I	L	Northwestern Ojibwa	
+ojc			oj	I	L	Central Ojibwa	
+ojg			oj	I	L	Eastern Ojibwa	
 oji	oji	oji	oj	M	L	Ojibwa	
 ojp				I	H	Old Japanese	
-ojs				I	L	Severn Ojibwa	
+ojs			oj	I	L	Severn Ojibwa	
 ojv				I	L	Ontong Java	
-ojw				I	L	Western Ojibwa	
+ojw			oj	I	L	Western Ojibwa	
 oka				I	L	Okanagan	
 okb				I	L	Okobo	
 okc				I	L	Kobo	
@@ -5061,22 +5061,22 @@ opo				I	L	Opao
 opt				I	E	Opata	
 opy				I	L	Ofayé	
 ora				I	L	Oroha	
-orc				I	L	Orma	
+orc			om	I	L	Orma	
 ore				I	L	Orejón	
 org				I	L	Oring	
 orh				I	L	Oroqen	
 ori	ori	ori	or	M	L	Oriya (macrolanguage)	
 orm	orm	orm	om	M	L	Oromo	
-orn				I	L	Orang Kanaq	
+orn			ms	I	L	Orang Kanaq	
 oro				I	L	Orokolo	
 orr				I	L	Oruma	
-ors				I	L	Orang Seletar	
+ors			ms	I	L	Orang Seletar	
 ort				I	L	Adivasi Oriya	
 oru				I	L	Ormuri	
 orv				I	H	Old Russian	
 orw				I	L	Oro Win	
 orx				I	L	Oro	
-ory				I	L	Odia	
+ory			or	I	L	Odia	
 orz				I	L	Ormu	
 osa	osa	osa		I	L	Osage	
 osc				I	A	Oscan	
@@ -5102,7 +5102,7 @@ otr				I	L	Otoro
 ots				I	L	Estado de México Otomi	
 ott				I	L	Temoaya Otomi	
 otu				I	E	Otuke	
-otw				I	L	Ottawa	
+otw			oj	I	L	Ottawa	
 otx				I	L	Texcatepec Otomi	
 oty				I	A	Old Tamil	
 otz				I	L	Ixtenco Otomi	
@@ -5156,8 +5156,8 @@ pbo				I	L	Papel
 pbp				I	L	Badyara	
 pbr				I	L	Pangwa	
 pbs				I	L	Central Pame	
-pbt				I	L	Southern Pashto	
-pbu				I	L	Northern Pashto	
+pbt			ps	I	L	Southern Pashto	
+pbu			ps	I	L	Northern Pashto	
 pbv				I	L	Pnar	
 pby				I	L	Pyu (Papua New Guinea)	
 pca				I	L	Santa Inés Ahuatempan Popoloca	
@@ -5193,12 +5193,12 @@ peh				I	L	Bonan
 pei				I	L	Chichimeca-Jonaz	
 pej				I	E	Northern Pomo	
 pek				I	L	Penchal	
-pel				I	L	Pekal	
+pel			ms	I	L	Pekal	
 pem				I	L	Phende	
 peo	peo	peo		I	H	Old Persian (ca. 600-400 B.C.)	
 pep				I	L	Kunja	
 peq				I	L	Southern Pomo	
-pes				I	L	Iranian Persian	
+pes			fa	I	L	Iranian Persian	
 pev				I	L	Pémono	
 pex				I	L	Petats	
 pey				I	L	Petjo	
@@ -5206,7 +5206,7 @@ pez				I	L	Eastern Penan
 pfa				I	L	Pááfang	
 pfe				I	L	Pere	
 pfl				I	L	Pfaelzisch	
-pga				I	L	Sudanese Creole Arabic	
+pga			ar	I	L	Sudanese Creole Arabic	
 pgd				I	H	Gāndhārī	
 pgg				I	L	Pangwali	
 pgi				I	L	Pagi	
@@ -5284,7 +5284,7 @@ plo				I	L	Oluta Popoluca
 plq				I	A	Palaic	
 plr				I	L	Palaka Senoufo	
 pls				I	L	San Marcos Tlacoyalco Popoloca	
-plt				I	L	Plateau Malagasy	
+plt			mg	I	L	Plateau Malagasy	
 plu				I	L	Palikúr	
 plv				I	L	Southwest Palawano	
 plw				I	L	Brooke's Point Palawano	
@@ -5385,7 +5385,7 @@ pro	pro	pro		I	H	Old Provençal (to 1500)
 prp				I	L	Parsi	
 prq				I	L	Ashéninka Perené	
 prr				I	E	Puri	
-prs				I	L	Dari	
+prs			fa	I	L	Dari	
 prt				I	L	Phai	
 pru				I	L	Puragi	
 prw				I	L	Parawen	
@@ -5394,7 +5394,7 @@ prz				I	L	Providencia Sign Language
 psa				I	L	Asue Awyu	
 psc				I	L	Iranian Sign Language	
 psd				I	L	Plains Indian Sign Language	
-pse				I	L	Central Malay	
+pse			ms	I	L	Central Malay	
 psg				I	L	Penang Sign Language	
 psh				I	L	Southwest Pashai	
 psi				I	L	Southeast Pashai	
@@ -5406,7 +5406,7 @@ psp				I	L	Philippine Sign Language
 psq				I	L	Pasi	
 psr				I	L	Portuguese Sign Language	
 pss				I	L	Kaulong	
-pst				I	L	Central Pashto	
+pst			ps	I	L	Central Pashto	
 psu				I	H	Sauraseni Prākrit	
 psw				I	L	Port Sandwich	
 psy				I	E	Piscataway	
@@ -5463,61 +5463,61 @@ pyy				I	L	Pyen
 pzh				I	L	Pazeh	
 pzn				I	L	Jejara Naga	
 qua				I	L	Quapaw	
-qub				I	L	Huallaga Huánuco Quechua	
+qub			qu	I	L	Huallaga Huánuco Quechua	
 quc				I	L	K'iche'	
-qud				I	L	Calderón Highland Quichua	
+qud			qu	I	L	Calderón Highland Quichua	
 que	que	que	qu	M	L	Quechua	
-quf				I	L	Lambayeque Quechua	
-qug				I	L	Chimborazo Highland Quichua	
-quh				I	L	South Bolivian Quechua	
+quf			qu	I	L	Lambayeque Quechua	
+qug			qu	I	L	Chimborazo Highland Quichua	
+quh			qu	I	L	South Bolivian Quechua	
 qui				I	L	Quileute	
-quk				I	L	Chachapoyas Quechua	
-qul				I	L	North Bolivian Quechua	
+quk			qu	I	L	Chachapoyas Quechua	
+qul			qu	I	L	North Bolivian Quechua	
 qum				I	L	Sipacapense	
 qun				I	E	Quinault	
-qup				I	L	Southern Pastaza Quechua	
+qup			qu	I	L	Southern Pastaza Quechua	
 quq				I	L	Quinqui	
-qur				I	L	Yanahuanca Pasco Quechua	
-qus				I	L	Santiago del Estero Quichua	
+qur			qu	I	L	Yanahuanca Pasco Quechua	
+qus			qu	I	L	Santiago del Estero Quichua	
 quv				I	L	Sacapulteco	
-quw				I	L	Tena Lowland Quichua	
-qux				I	L	Yauyos Quechua	
-quy				I	L	Ayacucho Quechua	
-quz				I	L	Cusco Quechua	
-qva				I	L	Ambo-Pasco Quechua	
-qvc				I	L	Cajamarca Quechua	
-qve				I	L	Eastern Apurímac Quechua	
-qvh				I	L	Huamalíes-Dos de Mayo Huánuco Quechua	
-qvi				I	L	Imbabura Highland Quichua	
-qvj				I	L	Loja Highland Quichua	
-qvl				I	L	Cajatambo North Lima Quechua	
-qvm				I	L	Margos-Yarowilca-Lauricocha Quechua	
-qvn				I	L	North Junín Quechua	
-qvo				I	L	Napo Lowland Quechua	
-qvp				I	L	Pacaraos Quechua	
-qvs				I	L	San Martín Quechua	
-qvw				I	L	Huaylla Wanca Quechua	
+quw			qu	I	L	Tena Lowland Quichua	
+qux			qu	I	L	Yauyos Quechua	
+quy			qu	I	L	Ayacucho Quechua	
+quz			qu	I	L	Cusco Quechua	
+qva			qu	I	L	Ambo-Pasco Quechua	
+qvc			qu	I	L	Cajamarca Quechua	
+qve			qu	I	L	Eastern Apurímac Quechua	
+qvh			qu	I	L	Huamalíes-Dos de Mayo Huánuco Quechua	
+qvi			qu	I	L	Imbabura Highland Quichua	
+qvj			qu	I	L	Loja Highland Quichua	
+qvl			qu	I	L	Cajatambo North Lima Quechua	
+qvm			qu	I	L	Margos-Yarowilca-Lauricocha Quechua	
+qvn			qu	I	L	North Junín Quechua	
+qvo			qu	I	L	Napo Lowland Quechua	
+qvp			qu	I	L	Pacaraos Quechua	
+qvs			qu	I	L	San Martín Quechua	
+qvw			qu	I	L	Huaylla Wanca Quechua	
 qvy				I	L	Queyu	
-qvz				I	L	Northern Pastaza Quichua	
-qwa				I	L	Corongo Ancash Quechua	
-qwc				I	H	Classical Quechua	
-qwh				I	L	Huaylas Ancash Quechua	
+qvz			qu	I	L	Northern Pastaza Quichua	
+qwa			qu	I	L	Corongo Ancash Quechua	
+qwc			qu	I	H	Classical Quechua	
+qwh			qu	I	L	Huaylas Ancash Quechua	
 qwm				I	E	Kuman (Russia)	
-qws				I	L	Sihuas Ancash Quechua	
+qws			qu	I	L	Sihuas Ancash Quechua	
 qwt				I	E	Kwalhioqua-Tlatskanai	
-qxa				I	L	Chiquián Ancash Quechua	
-qxc				I	L	Chincha Quechua	
-qxh				I	L	Panao Huánuco Quechua	
-qxl				I	L	Salasaca Highland Quichua	
-qxn				I	L	Northern Conchucos Ancash Quechua	
-qxo				I	L	Southern Conchucos Ancash Quechua	
-qxp				I	L	Puno Quechua	
+qxa			qu	I	L	Chiquián Ancash Quechua	
+qxc			qu	I	L	Chincha Quechua	
+qxh			qu	I	L	Panao Huánuco Quechua	
+qxl			qu	I	L	Salasaca Highland Quichua	
+qxn			qu	I	L	Northern Conchucos Ancash Quechua	
+qxo			qu	I	L	Southern Conchucos Ancash Quechua	
+qxp			qu	I	L	Puno Quechua	
 qxq				I	L	Qashqa'i	
-qxr				I	L	Cañar Highland Quichua	
+qxr			qu	I	L	Cañar Highland Quichua	
 qxs				I	L	Southern Qiang	
-qxt				I	L	Santa Ana de Tusi Pasco Quechua	
-qxu				I	L	Arequipa-La Unión Quechua	
-qxw				I	L	Jauja Wanca Quechua	
+qxt			qu	I	L	Santa Ana de Tusi Pasco Quechua	
+qxu			qu	I	L	Arequipa-La Unión Quechua	
+qxw			qu	I	L	Jauja Wanca Quechua	
 qya				I	C	Quenya	
 qyp				I	E	Quiripi	
 raa				I	L	Dungmali	
@@ -5752,15 +5752,15 @@ scw				I	L	Sha
 scx				I	A	Sicel	
 sda				I	L	Toraja-Sa'dan	
 sdb				I	L	Shabak	
-sdc				I	L	Sassarese Sardinian	
+sdc			sc	I	L	Sassarese Sardinian	
 sde				I	L	Surubu	
 sdf				I	L	Sarli	
 sdg				I	L	Savi	
-sdh				I	L	Southern Kurdish	
+sdh			ku	I	L	Southern Kurdish	
 sdj				I	L	Suundi	
 sdk				I	L	Sos Kundi	
 sdl				I	L	Saudi Arabian Sign Language	
-sdn				I	L	Gallurese Sardinian	
+sdn			sc	I	L	Gallurese Sardinian	
 sdo				I	L	Bukar-Sadung Bidayuh	
 sdp				I	L	Sherdukpen	
 sdq				I	L	Semandang	
@@ -5838,7 +5838,7 @@ shq				I	L	Sala
 shr				I	L	Shi	
 shs				I	L	Shuswap	
 sht				I	E	Shasta	
-shu				I	L	Chadian Arabic	
+shu			ar	I	L	Chadian Arabic	
 shv				I	L	Shehri	
 shw				I	L	Shwai	
 shx				I	L	She	
@@ -5889,7 +5889,7 @@ skc				I	L	Ma Manda
 skd				I	L	Southern Sierra Miwok	
 ske				I	L	Seke (Vanuatu)	
 skf				I	L	Sakirabiá	
-skg				I	L	Sakalava Malagasy	
+skg			mg	I	L	Sakalava Malagasy	
 skh				I	L	Sikule	
 ski				I	L	Sika	
 skj				I	L	Seke (Nepal)	
@@ -6019,7 +6019,7 @@ spr				I	L	Saparua
 sps				I	L	Saposa	
 spt				I	L	Spiti Bhoti	
 spu				I	L	Sapuan	
-spv				I	L	Sambalpuri	
+spv			or	I	L	Sambalpuri	
 spx				I	A	South Picene	
 spy				I	L	Sabaot	
 sqa				I	L	Shama-Sambuga	
@@ -6037,7 +6037,7 @@ squ				I	L	Squamish
 sqx				I	L	Kufr Qassem Sign Language (KQSL)	
 sra				I	L	Saruga	
 srb				I	L	Sora	
-src				I	L	Logudorese Sardinian	
+src			sc	I	L	Logudorese Sardinian	
 srd	srd	srd	sc	M	L	Sardinian	
 sre				I	L	Sara	
 srf				I	L	Nafi	
@@ -6048,7 +6048,7 @@ srk				I	L	Serudung Murut
 srl				I	L	Isirawa	
 srm				I	L	Saramaccan	
 srn	srn	srn		I	L	Sranan Tongo	
-sro				I	L	Campidanese Sardinian	
+sro			sc	I	L	Campidanese Sardinian	
 srp	srp	srp	sr	I	L	Serbian	
 srq				I	L	Sirionó	
 srr	srr	srr		I	L	Serer	
@@ -6066,7 +6066,7 @@ ssd				I	L	Siroi
 sse				I	L	Balangingi	
 ssf				I	L	Thao	
 ssg				I	L	Seimat	
-ssh				I	L	Shihhi Arabic	
+ssh			ar	I	L	Shihhi Arabic	
 ssi				I	L	Sansi	
 ssj				I	L	Sausi	
 ssk				I	L	Sunam	
@@ -6137,11 +6137,11 @@ svs				I	L	Savosavo
 svx				I	H	Skalvian	
 swa	swa	swa	sw	M	L	Swahili (macrolanguage)	
 swb				I	L	Maore Comorian	
-swc				I	L	Congo Swahili	
+swc			sw	I	L	Congo Swahili	
 swe	swe	swe	sv	I	L	Swedish	
 swf				I	L	Sere	
 swg				I	L	Swabian	
-swh				I	L	Swahili (individual language)	
+swh			sw	I	L	Swahili (individual language)	
 swi				I	L	Sui	
 swj				I	L	Sira	
 swk				I	L	Malawi Sena	
@@ -6291,7 +6291,7 @@ tdr				I	L	Todrah
 tds				I	L	Doutai	
 tdt				I	L	Tetun Dili	
 tdv				I	L	Toro	
-tdx				I	L	Tandroy-Mahafaly Malagasy	
+tdx			mg	I	L	Tandroy-Mahafaly Malagasy	
 tdy				I	L	Tadyawan	
 tea				I	L	Temiar	
 teb				I	E	Tetete	
@@ -6406,7 +6406,7 @@ tkb				I	L	Buksa
 tkd				I	L	Tukudede	
 tke				I	L	Takwane	
 tkf				I	E	Tukumanféd	
-tkg				I	L	Tesaka Malagasy	
+tkg			mg	I	L	Tesaka Malagasy	
 tkl	tkl	tkl		I	L	Tokelau	
 tkm				I	E	Takelma	
 tkn				I	L	Toku-No-Shima	
@@ -6464,7 +6464,7 @@ tms				I	L	Tima
 tmt				I	L	Tasmate	
 tmu				I	L	Iau	
 tmv				I	L	Tembo (Motembo)	
-tmw				I	L	Temuan	
+tmw			ms	I	L	Temuan	
 tmy				I	L	Tami	
 tmz				I	E	Tamanaku	
 tna				I	L	Tacana	
@@ -6696,7 +6696,7 @@ txs				I	L	Tonsea
 txt				I	L	Citak	
 txu				I	L	Kayapó	
 txx				I	L	Tatana	
-txy				I	L	Tanosy Malagasy	
+txy			mg	I	L	Tanosy Malagasy	
 tya				I	L	Tauya	
 tye				I	L	Kyanga	
 tyh				I	L	O'du	
@@ -6816,7 +6816,7 @@ urf				I	E	Uradhi
 urg				I	L	Urigina	
 urh				I	L	Urhobo	
 uri				I	L	Urim	
-urk				I	L	Urak Lawoi'	
+urk			ms	I	L	Urak Lawoi'	
 url				I	L	Urali	
 urm				I	L	Urapmin	
 urn				I	L	Uruangnirin	
@@ -6852,8 +6852,8 @@ uvl				I	L	Lote
 uwa				I	L	Kuku-Uwanh	
 uya				I	L	Doko-Uyanga	
 uzb	uzb	uzb	uz	M	L	Uzbek	
-uzn				I	L	Northern Uzbek	
-uzs				I	L	Southern Uzbek	
+uzn			uz	I	L	Northern Uzbek	
+uzs			uz	I	L	Southern Uzbek	
 vaa				I	L	Vaagri Booli	
 vae				I	L	Vale	
 vaf				I	L	Vafsi	
@@ -6895,13 +6895,13 @@ vit				I	L	Viti
 viv				I	L	Iduna	
 vka				I	E	Kariyarra	
 vkj				I	L	Kujarge	
-vkk				I	L	Kaur	
+vkk			ms	I	L	Kaur	
 vkl				I	L	Kulisusu	
 vkm				I	E	Kamakan	
 vkn				I	L	Koro Nulu	
 vko				I	L	Kodeoha	
 vkp				I	L	Korlai Creole Portuguese	
-vkt				I	L	Tenggarong Kutai Malay	
+vkt			ms	I	L	Tenggarong Kutai Malay	
 vku				I	L	Kurrama	
 vkz				I	L	Koro Zuba	
 vlp				I	L	Valpei	
@@ -6936,7 +6936,7 @@ vol	vol	vol	vo	I	C	Volapük
 vor				I	L	Voro	
 vot	vot	vot		I	L	Votic	
 vra				I	L	Vera'a	
-vro				I	L	Võro	
+vro			et	I	L	Võro	
 vrs				I	L	Varisi	
 vrt				I	L	Burmbar	
 vsi				I	L	Moldova Sign Language	
@@ -7156,7 +7156,7 @@ wum				I	L	Wumbvu
 wun				I	L	Bungu	
 wur				I	E	Wurrugu	
 wut				I	L	Wutung	
-wuu				I	L	Wu Chinese	
+wuu			zh	I	L	Wu Chinese	
 wuv				I	L	Wuvulu-Aua	
 wux				I	L	Wulna	
 wuy				I	L	Wauyai	
@@ -7321,7 +7321,7 @@ xmh				I	L	Kugu-Muminh
 xmj				I	L	Majera	
 xmk				I	A	Ancient Macedonian	
 xml				I	L	Malaysian Sign Language	
-xmm				I	L	Manado Malay	
+xmm			ms	I	L	Manado Malay	
 xmn				I	H	Manichaean Middle Persian	
 xmo				I	L	Morerebi	
 xmp				I	E	Kuku-Mu'inh	
@@ -7330,8 +7330,8 @@ xmr				I	A	Meroitic
 xms				I	L	Moroccan Sign Language	
 xmt				I	L	Matbat	
 xmu				I	E	Kamu	
-xmv				I	L	Antankarana Malagasy	
-xmw				I	L	Tsimihety Malagasy	
+xmv			mg	I	L	Antankarana Malagasy	
+xmw			mg	I	L	Tsimihety Malagasy	
 xmx				I	L	Salawati	
 xmy				I	L	Mayaguduna	
 xmz				I	L	Mori Bawah	
@@ -7533,7 +7533,7 @@ ycl				I	L	Lolopo
 ycn				I	L	Yucuna	
 ycp				I	L	Chepya	
 yda				I	E	Yanda	
-ydd				I	L	Eastern Yiddish	
+ydd			yi	I	L	Eastern Yiddish	
 yde				I	L	Yangum Dey	
 ydg				I	L	Yidgha	
 ydk				I	L	Yoidik	
@@ -7566,7 +7566,7 @@ yia				I	L	Yinggarda
 yid	yid	yid	yi	M	L	Yiddish	
 yif				I	L	Ache	
 yig				I	L	Wusa Nasu	
-yih				I	E	Western Yiddish	
+yih			yi	I	E	Western Yiddish	
 yii				I	L	Yidiny	
 yij				I	L	Yindjibarndi	
 yik				I	L	Dongshanba Lalo	
@@ -7686,7 +7686,7 @@ yua				I	L	Yucateco
 yub				I	E	Yugambal	
 yuc				I	L	Yuchi	
 yud				I	L	Judeo-Tripolitanian Arabic	
-yue				I	L	Yue Chinese	
+yue			zh	I	L	Yue Chinese	
 yuf				I	L	Havasupai-Walapai-Yavapai	
 yug				I	E	Yug	
 yui				I	L	Yurutí	
@@ -7759,23 +7759,23 @@ zbu				I	L	Bu (Bauchi State)
 zbw				I	L	West Berawan	
 zca				I	L	Coatecas Altas Zapotec	
 zcd	zcd	zcd		I	L	Las Delicias Zapotec	
-zch				I	L	Central Hongshuihe Zhuang	
+zch			za	I	L	Central Hongshuihe Zhuang	
 zdj				I	L	Ngazidja Comorian	
 zea				I	L	Zeeuws	
 zeg				I	L	Zenag	
-zeh				I	L	Eastern Hongshuihe Zhuang	
+zeh			za	I	L	Eastern Hongshuihe Zhuang	
 zen	zen	zen		I	L	Zenaga	
 zga				I	L	Kinga	
-zgb				I	L	Guibei Zhuang	
+zgb			za	I	L	Guibei Zhuang	
 zgh	zgh	zgh		I	L	Standard Moroccan Tamazight	
-zgm				I	L	Minz Zhuang	
-zgn				I	L	Guibian Zhuang	
+zgm			za	I	L	Minz Zhuang	
+zgn			za	I	L	Guibian Zhuang	
 zgr				I	L	Magori	
 zha	zha	zha	za	M	L	Zhuang	
 zhb				I	L	Zhaba	
-zhd				I	L	Dai Zhuang	
+zhd			za	I	L	Dai Zhuang	
 zhi				I	L	Zhire	
-zhn				I	L	Nong Zhuang	
+zhn			za	I	L	Nong Zhuang	
 zho	chi	zho	zh	M	L	Chinese	
 zhw				I	L	Zhoa	
 zia				I	L	Zia	
@@ -7801,10 +7801,10 @@ zku				I	L	Kaurna
 zkv				I	E	Krevinian	
 zkz				I	H	Khazar	
 zla				I	L	Zula	
-zlj				I	L	Liujiang Zhuang	
-zlm				I	L	Malay (individual language)	
-zln				I	L	Lianshan Zhuang	
-zlq				I	L	Liuqian Zhuang	
+zlj			za	I	L	Liujiang Zhuang	
+zlm			ms	I	L	Malay (individual language)	
+zln			za	I	L	Lianshan Zhuang	
+zlq			za	I	L	Liuqian Zhuang	
 zma				I	L	Manda (Australia)	
 zmb				I	L	Zimba	
 zmc				I	E	Margany	
@@ -7813,7 +7813,7 @@ zme				I	E	Mangerr
 zmf				I	L	Mfinu	
 zmg				I	L	Marti Ke	
 zmh				I	E	Makolkol	
-zmi				I	L	Negeri Sembilan Malay	
+zmi			ms	I	L	Negeri Sembilan Malay	
 zmj				I	L	Maridjabin	
 zmk				I	E	Mandandanyi	
 zml				I	E	Matngala	
@@ -7869,7 +7869,7 @@ zpw				I	L	Zaniza Zapotec
 zpx				I	L	San Baltazar Loxicha Zapotec	
 zpy				I	L	Mazaltepec Zapotec	
 zpz				I	L	Texmelucan Zapotec	
-zqe				I	L	Qiubei Zhuang	
+zqe			za	I	L	Qiubei Zhuang	
 zra				I	A	Kara (Korea)	
 zrg				I	L	Mirgan	
 zrn				I	L	Zerenkel	
@@ -7879,7 +7879,7 @@ zrs				I	L	Mairasi
 zsa				I	L	Sarasira	
 zsk				I	A	Kaskean	
 zsl				I	L	Zambian Sign Language	
-zsm				I	L	Standard Malay	
+zsm			ms	I	L	Standard Malay	
 zsr				I	L	Southern Rincon Zapotec	
 zsu				I	L	Sukurum	
 zte				I	L	Elotepec Zapotec	
@@ -7902,10 +7902,10 @@ zun	zun	zun		I	L	Zuni
 zuy				I	L	Zumaya	
 zwa				I	L	Zay	
 zxx	zxx	zxx		S	S	No linguistic content	
-zyb				I	L	Yongbei Zhuang	
-zyg				I	L	Yang Zhuang	
-zyj				I	L	Youjiang Zhuang	
-zyn				I	L	Yongnan Zhuang	
+zyb			za	I	L	Yongbei Zhuang	
+zyg			za	I	L	Yang Zhuang	
+zyj			za	I	L	Youjiang Zhuang	
+zyn			za	I	L	Yongnan Zhuang	
 zyp				I	L	Zyphe Chin	
 zza	zza	zza		M	L	Zaza	
-zzj				I	L	Zuojiang Zhuang	
+zzj			za	I	L	Zuojiang Zhuang	

--- a/iso639-autonyms.tsv
+++ b/iso639-autonyms.tsv
@@ -1,9 +1,9 @@
-tag3	tag1	name	autonym	source
+﻿tag3	tag1	name	autonym	source
 kap		Bezhta		iso639-3
 aar	aa	Afar	Qafar	cldr
 aaq		Eastern Abnaki		iso639-3
 aap		Pará Arára	Ukarãngmã	iso639-3, ethnologue
-aao		Algerian Saharan Arabic		iso639-3
+aao	ar	Algerian Saharan Arabic		iso639-3
 aan		Anambé		iso639-3
 aal		Afade		iso639-3
 aak		Ankave		iso639-3
@@ -11,7 +11,7 @@ aai		Arifama-Miniafia		iso639-3
 aah		Abu' Arapesh		iso639-3
 aag		Ambrak		iso639-3
 aaf		Aranadan		iso639-3
-aae		Arbëreshë Albanian		iso639-3
+aae	sq	Arbëreshë Albanian		iso639-3
 aad		Amal		iso639-3
 aac		Ari		iso639-3
 aab		Alumu-Tesu		iso639-3
@@ -132,29 +132,29 @@ azt		Faire Atta		iso639-3
 azo		Awing	Atembuluwe	iso639-3, ethnologue
 azn		Western Durango Nahuatl	Meshikan de San Agustin Buenaventura y de Santa Cruz	iso639-3, ethnologue
 azm		Ipalapa Amuzgo	Jñunda	iso639-3, ethnologue
-azj		North Azerbaijani	азәрбајҹан дили‎ (Azərbaycan dili), азәрбајҹанҹа‎ (azərbaycanca)	iso639-3, ethnologue
+azj	az	North Azerbaijani	азәрбајҹан дили‎ (Azərbaycan dili), азәрбајҹанҹа‎ (azərbaycanca)	iso639-3, ethnologue
 azg		San Pedro Amuzgos Amuzgo	Jnꞌoon	iso639-3, ethnologue
 azd		Eastern Durango Nahuatl	Meshikan de San Pedro Shikora	iso639-3, ethnologue
-azb		South Azerbaijani	آذربایجان دیلی‎ (Azərbaycan dili), آذربایجانجا‎ (Azərbaycanca)	iso639-3, ethnologue
+azb	az	South Azerbaijani	آذربایجان دیلی‎ (Azərbaycan dili), آذربایجانجا‎ (Azərbaycanca)	iso639-3, ethnologue
 aza		Azha		iso639-3
 ayz		Mai Brat		iso639-3
 ayy		Tayabas Ayta		iso639-3
 ayu		Ayu		iso639-3
 ayt		Magbukun Ayta		iso639-3
 ays		Sorsogon Ayta		iso639-3
-ayr		Central Aymara	Aymar	iso639-3, ethnologue
+ayr	ay	Central Aymara	Aymar	iso639-3, ethnologue
 ayq		Ayi (Papua New Guinea)		iso639-3
-ayp		North Mesopotamian Arabic		iso639-3
+ayp	ar	North Mesopotamian Arabic		iso639-3
 ayo		Ayoreo	Morotoco	iso639-3, ethnologue
-ayn		Sanaani Arabic		iso639-3
-ayl		Libyan Arabic	ليبي‎ (Lībi)	iso639-3, ethnologue
+ayn	ar	Sanaani Arabic		iso639-3
+ayl	ar	Libyan Arabic	ليبي‎ (Lībi)	iso639-3, ethnologue
 ayk		Akuku		iso639-3
 ayi		Leyigha		iso639-3
-ayh		Hadrami Arabic		iso639-3
+ayh	ar	Hadrami Arabic		iso639-3
 ayg		Ginyanga		iso639-3
 aye		Ayere		iso639-3
 ayd		Ayabadhu		iso639-3
-ayc		Southern Aymara		iso639-3
+ayc	ay	Southern Aymara		iso639-3
 ayb		Ayizo Gbe	Ayizo Gbe	iso639-3, ethnologue
 aya		Awar		iso639-3
 axx		Xârâgurè		iso639-3
@@ -199,7 +199,7 @@ aka	ak	Akan	Akan	cldr
 afr	af	Afrikaans	Afrikaans	cldr
 ave	ae	Avestan		cldr
 aas		Aasáx		iso639-3
-aat		Arvanitika Albanian		iso639-3
+aat	sq	Arvanitika Albanian		iso639-3
 aau		Abau	Abau	iso639-3, ethnologue
 aaw		Solong	Solong	iso639-3, ethnologue
 aax		Mandobo Atas		iso639-3
@@ -211,7 +211,7 @@ abd		Manide		iso639-3
 abe		Western Abnaki	Alnôbak	iso639-3, ethnologue
 abf		Abai Sungai		iso639-3
 abg		Abaga		iso639-3
-abh		Tajiki Arabic		iso639-3
+abh	ar	Tajiki Arabic		iso639-3
 abi		Abidji		iso639-3
 abj		Aka-Bea		iso639-3
 abl		Lampung Nyo		iso639-3
@@ -224,7 +224,7 @@ abr		Abron	Brong	iso639-3, ethnologue
 abs		Ambonese Malay	Bahasa Ambon, Bahasa Melaju Ambon	iso639-3, ethnologue
 abt		Ambulas	Ambulas	iso639-3, ethnologue
 abu		Abure		iso639-3
-abv		Baharna Arabic	العربية البحرانية‎ (Arab Bahraini)	iso639-3, ethnologue
+abv	ar	Baharna Arabic	العربية البحرانية‎ (Arab Bahraini)	iso639-3, ethnologue
 abw		Pal		iso639-3
 abx		Inabaknon	Inabaknon	iso639-3, ethnologue
 aby		Aneme Wake		iso639-3
@@ -238,24 +238,24 @@ ach		Acoli		cldr
 aci		Aka-Cari		iso639-3
 ack		Aka-Kora		iso639-3
 acl		Akar-Bale		iso639-3
-acm		Mesopotamian Arabic	عراقي‎ (ʕirāgi)	iso639-3, ethnologue
+acm	ar	Mesopotamian Arabic	عراقي‎ (ʕirāgi)	iso639-3, ethnologue
 acn		Achang	Ngochang	iso639-3, ethnologue
 acp		Eastern Acipa		iso639-3
-acq		Ta'izzi-Adeni Arabic		iso639-3
+acq	ar	Ta'izzi-Adeni Arabic		iso639-3
 acr		Achi	Qach’a’teem	iso639-3, ethnologue
 acs		Acroá		iso639-3
 act		Achterhoeks		iso639-3
 acu		Achuar-Shiwiar	Achuar Chicham, Shiwiar Chicham	iso639-3, ethnologue
 acv		Achumawi		iso639-3
-acw		Hijazi Arabic		iso639-3
-acx		Omani Arabic		iso639-3
-acy		Cypriot Arabic	Sanna	iso639-3, ethnologue
+acw	ar	Hijazi Arabic		iso639-3
+acx	ar	Omani Arabic		iso639-3
+acy	ar	Cypriot Arabic	Sanna	iso639-3, ethnologue
 acz		Acheron	Garme	iso639-3, ethnologue
 ada		Adangme		cldr
 adb		Adabe		iso639-3
 add		Dzodinka		iso639-3
 ade		Adele	Gidire	iso639-3, ethnologue
-adf		Dhofari Arabic		iso639-3
+adf	ar	Dhofari Arabic		iso639-3
 adg		Andegerebinha		iso639-3
 adh		Adhola	Dhopadhola	iso639-3, ethnologue
 adi		Adi	Adi	iso639-3, ethnologue
@@ -273,8 +273,8 @@ adx		Amdo Tibetan		iso639-3
 ady		Adyghe	Адыгабзэ‎ (Adəgăbză)	cldr, ethnologue
 adz		Adzera	Adzera	iso639-3, ethnologue
 aea		Areba		iso639-3
-aeb		Tunisian Arabic	Derja, تونسي‎ (Tounsi)	cldr, ethnologue
-aec		Saidi Arabic		iso639-3
+aeb	ar	Tunisian Arabic	Derja, تونسي‎ (Tounsi)	cldr, ethnologue
+aec	ar	Saidi Arabic		iso639-3
 aed		Argentine Sign Language		iso639-3
 aee		Northeast Pashai		iso639-3
 aek		Haeke		iso639-3
@@ -288,7 +288,7 @@ aeu		Akeu		iso639-3
 aew		Ambakich		iso639-3
 aey		Amele	Amele	iso639-3, ethnologue
 aez		Aeka	Aeka	iso639-3, ethnologue
-afb		Gulf Arabic	خليجي‎ (Khaliji)	iso639-3, ethnologue
+afb	ar	Gulf Arabic	خليجي‎ (Khaliji)	iso639-3, ethnologue
 afd		Andai		iso639-3
 afe		Putukwam		iso639-3
 afg		Afghan Sign Language		iso639-3
@@ -408,12 +408,12 @@ alj		Alangan		iso639-3
 alk		Alak		iso639-3
 all		Allar		iso639-3
 alm		Amblong		iso639-3
-aln		Gheg Albanian	Gegnisht-Shqyp, Shqyp	cldr, ethnologue
+aln	sq	Gheg Albanian	Gegnisht-Shqyp, Shqyp	cldr, ethnologue
 alo		Larike-Wakasihu		iso639-3
 alp		Alune		iso639-3
 alq		Algonquin	Anishinaabemowin	iso639-3, ethnologue
 alr		Alutor		iso639-3
-als		Tosk Albanian	Shqip	iso639-3, ethnologue
+als	sq	Tosk Albanian	Shqip	iso639-3, ethnologue
 alt		Southern Altai	алтай тили‎ (Altay tili), алтайча‎ (Altajča)	cldr, ethnologue
 alu		'Are'are	’Are’are	iso639-3, ethnologue
 alw		Alaba-K’abeena		iso639-3
@@ -491,8 +491,8 @@ aou		A'ou		iso639-3
 aox		Atorada		iso639-3
 aoz		Uab Meto	Uab Meto	iso639-3, ethnologue
 apb		Sa'a		iso639-3
-apc		North Levantine Arabic	اللهجة العربيّة السورىّة‎ (El-lahjeẗ el-‛arabīyeẗ es-sūrīyé)	iso639-3, ethnologue
-apd		Sudanese Arabic	Arabi	iso639-3, ethnologue
+apc	ar	North Levantine Arabic	اللهجة العربيّة السورىّة‎ (El-lahjeẗ el-‛arabīyeẗ es-sūrīyé)	iso639-3, ethnologue
+apd	ar	Sudanese Arabic	Arabi	iso639-3, ethnologue
 ape		Bukiyip		iso639-3
 apf		Pahanan Agta		iso639-3
 apg		Ampanang		iso639-3
@@ -524,7 +524,7 @@ aqp		Atakapa		iso639-3
 aqr		Arhâ		iso639-3
 aqt		Angaité		iso639-3
 aqz		Akuntsu		iso639-3
-arb		Standard Arabic	العربية‎ (al-ʻArabīyah)	iso639-3, ethnologue
+arb	ar	Standard Arabic	العربية‎ (al-ʻArabīyah)	iso639-3, ethnologue
 arc		Aramaic		cldr
 ard		Arabana		iso639-3
 are		Western Arrarnta	Arrente	iso639-3, ethnologue
@@ -536,15 +536,15 @@ arl		Arabela	Tapueyocaca	iso639-3, ethnologue
 arn		Mapuche	Mapudungun	cldr
 aro		Araona		cldr
 arp		Arapaho	Hinónoʼeitíít	cldr, ethnologue
-arq		Algerian Arabic	دزيرية‎ (Dziria)	cldr, ethnologue
+arq	ar	Algerian Arabic	دزيرية‎ (Dziria)	cldr, ethnologue
 arr		Karo (Brazil)		iso639-3
-ars		Najdi Arabic		cldr
+ars	ar	Najdi Arabic		cldr
 aru		Aruá (Amazonas State)		iso639-3
 arv		Arbore		iso639-3
 arw		Arawak	Arawak, Lokono	cldr, ethnologue
 arx		Aruá (Rodonia State)		iso639-3
-ary		Moroccan Arabic	الدارجة‎ (Darija)	cldr, ethnologue
-arz		Egyptian Arabic	مصري‎ (Masri)	cldr, ethnologue
+ary	ar	Moroccan Arabic	الدارجة‎ (Darija)	cldr, ethnologue
+arz	ar	Egyptian Arabic	مصري‎ (Masri)	cldr, ethnologue
 asa		Asu	Kipare	cldr
 asb		Assiniboine		iso639-3
 asc		Casuarina Coast Asmat		iso639-3
@@ -615,12 +615,12 @@ auu		Auye		iso639-3
 auw		Awyi		iso639-3
 aux		Aurá		iso639-3
 auy		Awiyaana		iso639-3
-auz		Uzbeki Arabic		iso639-3
+auz	ar	Uzbeki Arabic		iso639-3
 avb		Avau		iso639-3
 avd		Alviri-Vidari		iso639-3
 avi		Avikam		iso639-3
 avk		Kotava		cldr
-avl		Eastern Egyptian Bedawi Arabic		iso639-3
+avl	ar	Eastern Egyptian Bedawi Arabic		iso639-3
 avm		Angkamuthi		iso639-3
 avn		Avatime	Si-yà	iso639-3, ethnologue
 avo		Agavotaguerra		iso639-3
@@ -656,7 +656,7 @@ btp		Budibud		iso639-3
 bto		Rinconada Bikol		iso639-3
 btn		Ratagnon		iso639-3
 btm		Batak Mandailing		iso639-3
-btj		Bacanese Malay		iso639-3
+btj	ms	Bacanese Malay		iso639-3
 bti		Burate		iso639-3
 bth		Biatah Bidayuh		iso639-3
 btg		Gagnoa Bété		iso639-3
@@ -868,7 +868,7 @@ bhn		Bohtan Neo-Aramaic		iso639-3
 bho		Bhojpuri	भोजपुरी‎ (Bhōjpurī)	cldr, ethnologue
 bhp		Bima		iso639-3
 bhq		Tukang Besi South		iso639-3
-bhr		Bara Malagasy		iso639-3
+bhr	mg	Bara Malagasy		iso639-3
 bhs		Buwal	Buwal	iso639-3, ethnologue
 bht		Bhattiyali		iso639-3
 bhu		Bhunjia		iso639-3
@@ -912,7 +912,7 @@ bjj		Kanauji	देहाती‎ (Dehati), हिन्दी‎ (Hindi)	iso63
 bjk		Barok		iso639-3
 bjl		Bulu (Papua New Guinea)		iso639-3
 bjm		Bajelani		iso639-3
-bjn		Banjar	بنجر‎ (Banjar)	cldr, ethnologue
+bjn	ms	Banjar	بنجر‎ (Banjar)	cldr, ethnologue
 bjo		Mid-Southern Banda		iso639-3
 bjp		Fanamaket		iso639-3
 bjr		Binumarien	Binumarien	iso639-3, ethnologue
@@ -985,7 +985,7 @@ bmi		Bagirmi	Barma	iso639-3, ethnologue
 bmj		Bote-Majhi		iso639-3
 bmk		Ghayavi		iso639-3
 bml		Bomboli		iso639-3
-bmm		Northern Betsimisaraka Malagasy		iso639-3
+bmm	mg	Northern Betsimisaraka Malagasy		iso639-3
 bmn		Bina (Papua New Guinea)		iso639-3
 bmo		Bambalang	Chrambo, Mboyakum	iso639-3, ethnologue
 bmp		Bulgebi		iso639-3
@@ -1059,7 +1059,7 @@ bzg		Babuza		iso639-3
 bzf		Boikin		iso639-3
 bze		Jenaama Bozo		iso639-3
 bzd		Bribri	Bribri	iso639-3, ethnologue
-bzc		Southern Betsimisaraka Malagasy		iso639-3
+bzc	mg	Southern Betsimisaraka Malagasy		iso639-3
 bzb		Andio		iso639-3
 bza		Bandi		iso639-3
 byz		Banaro		iso639-3
@@ -1139,7 +1139,7 @@ bvy		Baybayanon		iso639-3
 bvx		Dibole		iso639-3
 bvw		Boga		iso639-3
 bvv		Baniva		iso639-3
-bvu		Bukit Malay		iso639-3
+bvu	ms	Bukit Malay		iso639-3
 bvt		Bati (Indonesia)		iso639-3
 bvr		Burarra		iso639-3
 bvq		Birri		iso639-3
@@ -1154,7 +1154,7 @@ bvi		Belanda Viri	Viri	iso639-3, ethnologue
 bvh		Bure		iso639-3
 bvg		Bonkeng		iso639-3
 bvf		Boor		iso639-3
-bve		Berau Malay		iso639-3
+bve	ms	Berau Malay		iso639-3
 bvd		Baeggu		iso639-3
 bvc		Baelelea		iso639-3
 bvb		Bube		iso639-3
@@ -1374,7 +1374,7 @@ cdi		Chodri		iso639-3
 cdj		Churahi		iso639-3
 cdm		Chepang		iso639-3
 cdn		Chaudangsi		iso639-3
-cdo		Min Dong Chinese	平話‎ (Bangua), 闽东话‎ (Mindongyu)	iso639-3, ethnologue
+cdo	zh	Min Dong Chinese	平話‎ (Bangua), 闽东话‎ (Mindongyu)	iso639-3, ethnologue
 cdr		Cinda-Regi-Tiyal		iso639-3
 cds		Chadian Sign Language		iso639-3
 wog		Wogamusin		iso639-3
@@ -1424,7 +1424,7 @@ cim		Cimbrian		iso639-3
 cin		Cinta Larga		iso639-3
 cip		Chiapanec		iso639-3
 cir		Tiri		iso639-3
-ciw		Chippewa		iso639-3
+ciw	oj	Chippewa		iso639-3
 ciy		Chaima		iso639-3
 cja		Western Cham	Cham	iso639-3, ethnologue
 cje		Chru		iso639-3
@@ -1437,8 +1437,8 @@ cjo		Ashéninka Pajonal		iso639-3
 cjp		Cabécar	Cabécar	iso639-3, ethnologue
 cjs		Shor		iso639-3
 cjv		Chuave		iso639-3
-cjy		Jinyu Chinese	晋语‎ (Jin)	iso639-3, ethnologue
-ckb		Central Kurdish	کوردیی ناوەندی	cldr
+cjy	zh	Jinyu Chinese	晋语‎ (Jin)	iso639-3, ethnologue
+ckb	ku	Central Kurdish	کوردیی ناوەندی	cldr
 ckh		Chak		iso639-3
 ckl		Cibak		iso639-3
 ckn		Kaang Chin	Kaang Chin	iso639-3, ethnologue
@@ -1473,7 +1473,7 @@ cmg		Classical Mongolian		iso639-3
 cmi		Emberá-Chamí		iso639-3
 cml		Campalagian		iso639-3
 cmm		Michigamea		iso639-3
-cmn		Mandarin Chinese	普通话‎ (Putonghua)	iso639-3, ethnologue
+cmn	zh	Mandarin Chinese	普通话‎ (Putonghua)	iso639-3, ethnologue
 cmo		Central Mnong		iso639-3
 cmr		Mro-Khimi Chin	Khimi, Mro-Khimi	iso639-3, ethnologue
 cms		Messapic		iso639-3
@@ -1492,7 +1492,7 @@ cnt		Tepetotutla Chinantec	Jajmi dzä kï ï’, Jejmi	iso639-3, ethnologue
 cnu		Chenoua		iso639-3
 cnw		Ngawn Chin		iso639-3
 cnx		Middle Cornish		iso639-3
-coa		Cocos Islands Malay		iso639-3
+coa	ms	Cocos Islands Malay		iso639-3
 cob		Chicomuceltec		iso639-3
 coc		Cocopa	Kuapá	iso639-3, ethnologue
 cod		Cocama-Cocamilla		iso639-3
@@ -1523,7 +1523,7 @@ cpn		Cherepon		iso639-3
 cpo		Kpeego		iso639-3
 cps		Capiznon		cldr
 cpu		Pichis Ashéninka		iso639-3
-cpx		Pu-Xian Chinese		iso639-3
+cpx	zh	Pu-Xian Chinese		iso639-3
 cpy		South Ucayali Ashéninka		iso639-3
 cqd		Chuanqiandian Cluster Miao		iso639-3
 cra		Chara		iso639-3
@@ -1534,10 +1534,10 @@ crf		Caramanta		iso639-3
 crg		Michif		iso639-3
 crh		Crimean Turkish	Qirim, Qirimtatar	cldr, ethnologue
 cri		Sãotomense		iso639-3
-crj		Southern East Cree	ᐄᓅ ᐊᔨᒨᓐ, Īnū Ayimūn 	github
-crk		Plains Cree	ᓀᐦᐃᔭᐍᐏᐣ, Nēhiyawēwin	github
-crl		Northern East Cree	ᐄᔨᔫ ᐊᔨᒨᓐ, Īyiyū Ayimūn 	github
-crm		Moose Cree	Mōsonī, Ililiw	github
+crj	cr	Southern East Cree	ᐄᓅ ᐊᔨᒨᓐ, Īnū Ayimūn 	github
+crk	cr	Plains Cree	ᓀᐦᐃᔭᐍᐏᐣ, Nēhiyawēwin	github
+crl	cr	Northern East Cree	ᐄᔨᔫ ᐊᔨᒨᓐ, Īyiyū Ayimūn 	github
+crm	cr	Moose Cree	Mōsonī, Ililiw	github
 crn		El Nayar Cora	Naáyeri	iso639-3, ethnologue
 cro		Crow		iso639-3
 crq		Iyo'wujwa Chorote	Yojwaja	iso639-3, ethnologue
@@ -1569,7 +1569,7 @@ csr		Costa Rican Sign Language		iso639-3
 css		Southern Ohlone		iso639-3
 cst		Northern Ohlone		iso639-3
 csv		Sumtu Chin	Cumtu, Sumtu Chin	iso639-3, ethnologue
-csw		Swampy Cree		iso639-3
+csw	cr	Swampy Cree		iso639-3
 csy		Siyin Chin		iso639-3
 csz		Coos		iso639-3
 cta		Tataltepec Chatino	Cha’ jna’a	iso639-3, ethnologue
@@ -1609,17 +1609,17 @@ cvg		Chug		iso639-3
 cvn		Valle Nacional Chinantec		iso639-3
 cwa		Kabwa		iso639-3
 cwb		Maindo		iso639-3
-cwd		Woods Cree		iso639-3
+cwd	cr	Woods Cree		iso639-3
 cwe		Kwere	Nghwele	iso639-3, ethnologue
 cwg		Chewong		iso639-3
 cwt		Kuwaataay		iso639-3
 cya		Nopala Chatino	Cha’ jna’a	iso639-3, ethnologue
 cyb		Cayubaba		iso639-3
 cyo		Cuyonon		iso639-3
-czh		Huizhou Chinese		iso639-3
+czh	zh	Huizhou Chinese		iso639-3
 czk		Knaanic		iso639-3
 czn		Zenzontepec Chatino	Cha’ jna’a	iso639-3, ethnologue
-czo		Min Zhong Chinese		iso639-3
+czo	zh	Min Zhong Chinese		iso639-3
 czt		Zotung Chin	Zotung, Zotung Chin	iso639-3, ethnologue
 daa		Dangaléat		iso639-3
 dac		Dambi		iso639-3
@@ -1861,7 +1861,7 @@ dtr		Lotud		iso639-3
 dts		Toro So Dogon		iso639-3
 dtt		Toro Tegu Dogon		iso639-3
 dtu		Tebul Ure Dogon		iso639-3
-dty		Dotyali		iso639-3
+dty	ne	Dotyali		iso639-3
 dua		Duala	duálá	cldr
 dub		Dubli		iso639-3
 duc		Duna		iso639-3
@@ -1876,7 +1876,7 @@ dul		Alabat Island Agta		iso639-3
 dum		Middle Dutch		cldr
 dun		Dusun Deyah		iso639-3
 duo		Dupaninan Agta		iso639-3
-dup		Duano		iso639-3
+dup	ms	Duano		iso639-3
 duq		Dusun Malang		iso639-3
 dur		Dii		iso639-3
 dus		Dumi		iso639-3
@@ -1935,7 +1935,7 @@ ekc		Eastern Karnic		iso639-3
 eke		Ekit		iso639-3
 ekg		Ekari	Me	iso639-3, ethnologue
 eki		Eki		iso639-3
-ekk		Standard Estonian	Eesti Kirjakeel	iso639-3, ethnologue
+ekk	et	Standard Estonian	Eesti Kirjakeel	iso639-3, ethnologue
 ekl		Kol (Bangladesh)		iso639-3
 ekm		Elip	Nulibié	iso639-3, ethnologue
 eko		Koti		iso639-3
@@ -1995,8 +1995,8 @@ erw		Erokwanas		iso639-3
 ese		Ese Ejja		iso639-3
 esg		Aheri Gondi		iso639-3
 esh		Eshtehardi		iso639-3
-esi		North Alaskan Inupiatun		iso639-3
-esk		Northwest Alaska Inupiatun		iso639-3
+esi	ik	North Alaskan Inupiatun		iso639-3
+esk	ik	Northwest Alaska Inupiatun		iso639-3
 esl		Egypt Sign Language		iso639-3
 esm		Esuma		iso639-3
 esn		Salvadoran Sign Language		iso639-3
@@ -2039,7 +2039,7 @@ fam		Fam		iso639-3
 fan		Fang	Fang	cldr, ethnologue
 fap		Palor	Paloor	iso639-3, ethnologue
 far		Fataleka		iso639-3
-fat		Fanti		cldr
+fat	ak	Fanti		cldr
 fau		Fayu		iso639-3
 fax		Fala	Fala, Nosa Fala	iso639-3, ethnologue
 fay		Southwestern Fars		iso639-3
@@ -2048,7 +2048,7 @@ fbl		West Albay Bikol	Bikol	iso639-3, ethnologue
 fcs		Quebec Sign Language		iso639-3
 fer		Feroge		iso639-3
 ffi		Foia Foia	Foia Foia	iso639-3, ethnologue
-ffm		Maasina Fulfulde		iso639-3
+ffm	ff	Maasina Fulfulde		iso639-3
 fgr		Fongoro		iso639-3
 fia		Nobiin		iso639-3
 fie		Fyer		iso639-3
@@ -2092,21 +2092,21 @@ frt		Fortsenal		iso639-3
 fse		Finnish Sign Language		iso639-3
 fsl		French Sign Language		iso639-3
 fss		Finland-Swedish Sign Language		iso639-3
-fub		Adamawa Fulfulde	Fulfulde	iso639-3, ethnologue
-fuc		Pulaar		iso639-3
+fub	ff	Adamawa Fulfulde	Fulfulde	iso639-3, ethnologue
+fuc	ff	Pulaar		iso639-3
 fud		East Futuna		iso639-3
-fue		Borgu Fulfulde		iso639-3
-fuf		Pular	Pular	iso639-3, ethnologue
-fuh		Western Niger Fulfulde	Fulfulde	iso639-3, ethnologue
-fui		Bagirmi Fulfulde		iso639-3
+fue	ff	Borgu Fulfulde		iso639-3
+fuf	ff	Pular	Pular	iso639-3, ethnologue
+fuh	ff	Western Niger Fulfulde	Fulfulde	iso639-3, ethnologue
+fui	ff	Bagirmi Fulfulde		iso639-3
 fuj		Ko		iso639-3
 fum		Fum		iso639-3
 fun		Fulniô		iso639-3
-fuq		Central-Eastern Niger Fulfulde		iso639-3
+fuq	ff	Central-Eastern Niger Fulfulde		iso639-3
 fur		Friulian	furlan	cldr
 fut		Futuna-Aniwa		iso639-3
 fuu		Furu		iso639-3
-fuv		Nigerian Fulfulde	Fulfulde	iso639-3, ethnologue
+fuv	ff	Nigerian Fulfulde	Fulfulde	iso639-3, ethnologue
 fuy		Fuyug		iso639-3
 fvr		Fur		iso639-3
 fwa		Fwâi		iso639-3
@@ -2124,7 +2124,7 @@ gaj		Gadsup		iso639-3
 gak		Gamkonora		iso639-3
 gal		Galolen		iso639-3
 gam		Kandawo		iso639-3
-gan		Gan Chinese		cldr
+gan	zh	Gan Chinese		cldr
 gao		Gants		iso639-3
 gap		Gal		iso639-3
 gaq		Gata'		iso639-3
@@ -2133,9 +2133,9 @@ gas		Adiwasi Garasia		iso639-3
 gat		Kenati		iso639-3
 gau		Mudhili Gadaba		iso639-3
 gaw		Nobonob		iso639-3
-gax		Borana-Arsi-Guji Oromo		iso639-3
+gax	om	Borana-Arsi-Guji Oromo		iso639-3
 gay		Gayo		cldr
-gaz		West Central Oromo	Afaan Oromoo, Oromiffa	iso639-3, ethnologue
+gaz	om	West Central Oromo	Afaan Oromoo, Oromiffa	iso639-3, ethnologue
 gba		Gbaya		cldr
 gbb		Kaytetye		iso639-3
 gbd		Karadjeri		iso639-3
@@ -2303,7 +2303,7 @@ gnq		Gana		iso639-3
 gnr		Gureng Gureng		iso639-3
 gnt		Guntai		iso639-3
 gnu		Gnau		iso639-3
-gnw		Western Bolivian Guaraní		iso639-3
+gnw	gn	Western Bolivian Guaraní		iso639-3
 gnz		Ganzi		iso639-3
 goa		Guro	Golo	iso639-3, ethnologue
 gob		Playero		iso639-3
@@ -2375,13 +2375,13 @@ guc		Wayuu		cldr
 gud		Yocoboué Dida		iso639-3
 gue		Gurinji		iso639-3
 guf		Gupapuyngu		iso639-3
-gug		Paraguayan Guaraní	Guaraní	iso639-3, ethnologue
+gug	gn	Paraguayan Guaraní	Guaraní	iso639-3, ethnologue
 guh		Guahibo	Hivi	iso639-3, ethnologue
-gui		Eastern Bolivian Guaraní		iso639-3
+gui	gn	Eastern Bolivian Guaraní		iso639-3
 guk		Gumuz	Bega-Tse, Sigumza	iso639-3, ethnologue
 gul		Sea Island Creole English		iso639-3
 gum		Guambiano		iso639-3
-gun		Mbyá Guaraní	Mbya	iso639-3, ethnologue
+gun	gn	Mbyá Guaraní	Mbya	iso639-3, ethnologue
 guo		Guayabero		iso639-3
 gup		Gunwinggu		iso639-3
 guq		Aché	Aché	iso639-3, ethnologue
@@ -2441,13 +2441,13 @@ haa		Han		iso639-3
 hab		Hanoi Sign Language		iso639-3
 hac		Gurani		iso639-3
 had		Hatam		iso639-3
-hae		Eastern Oromo		iso639-3
+hae	om	Eastern Oromo		iso639-3
 haf		Haiphong Sign Language		iso639-3
 hag		Hanga		iso639-3
 hah		Hahon		iso639-3
 hai		Haida		cldr
 haj		Hajong		iso639-3
-hak		Hakka Chinese	客家話‎ (Hakkafa)	cldr, ethnologue
+hak	zh	Hakka Chinese	客家話‎ (Hakkafa)	cldr, ethnologue
 hal		Halang		iso639-3
 ham		Hewa		iso639-3
 han		Hangaza		iso639-3
@@ -2497,7 +2497,7 @@ hir		Himarimã		iso639-3
 hit		Hittite		cldr
 hiw		Hiw		iso639-3
 hix		Hixkaryána		iso639-3
-hji		Haji		iso639-3
+hji	ms	Haji		iso639-3
 hka		Kahe		iso639-3
 hke		Hunde		iso639-3
 hkk		Hunjara-Kaina Ke		iso639-3
@@ -2578,7 +2578,7 @@ hrz		Harzani		iso639-3
 hsb		Upper Sorbian	hornjoserbšćina	cldr
 hsh		Hungarian Sign Language		iso639-3
 hsl		Hausa Sign Language		iso639-3
-hsn		Xiang Chinese	湘语‎ (Xiang)	cldr, ethnologue
+hsn	zh	Xiang Chinese	湘语‎ (Xiang)	cldr, ethnologue
 hss		Harsusi		iso639-3
 hti		Hoti		iso639-3
 hto		Minica Huitoto		iso639-3
@@ -2674,7 +2674,7 @@ ije		Biseni		iso639-3
 ijj		Ede Ije		iso639-3
 ijn		Kalabari		iso639-3
 ijs		Southeast Ijo		iso639-3
-ike		Eastern Canadian Inuktitut	ᐃᓄᒃᑎᑐᑦ‎ (Inuktitut)	iso639-3, ethnologue
+ike	iu	Eastern Canadian Inuktitut	ᐃᓄᒃᑎᑐᑦ‎ (Inuktitut)	iso639-3, ethnologue
 iki		Iko		iso639-3
 ikk		Ika		iso639-3
 ikl		Ikulu		iso639-3
@@ -2682,7 +2682,7 @@ iko		Olulumo-Ikom		iso639-3
 ikp		Ikpeshi		iso639-3
 ikr		Ikaranggal		iso639-3
 iks		Inuit Sign Language		iso639-3
-ikt		Inuinnaqtun	Inuinnaqtun, ᐃᓄᐃᓐᓇᖅᑐᓐ‎ (Inuvialuktun)	iso639-3, ethnologue
+ikt	iu	Inuinnaqtun	Inuinnaqtun, ᐃᓄᐃᓐᓇᖅᑐᓐ‎ (Inuvialuktun)	iso639-3, ethnologue
 ikv		Iku-Gora-Ankwa		iso639-3
 ikw		Ikwere		iso639-3
 ikx		Ik	Icetod	iso639-3, ethnologue
@@ -2787,7 +2787,7 @@ jae		Yabem		iso639-3
 jaf		Jara		iso639-3
 jah		Jah Hut		iso639-3
 jaj		Zazao		iso639-3
-jak		Jakun		iso639-3
+jak	ms	Jakun		iso639-3
 jal		Yalahatan		iso639-3
 jam		Jamaican Creole English		cldr
 jan		Jandai		iso639-3
@@ -2796,7 +2796,7 @@ jaq		Yaqay		iso639-3
 jas		New Caledonian Javanese		iso639-3
 jat		Jakati		iso639-3
 jau		Yaur		iso639-3
-jax		Jambi Malay	Bahaso Daerah, Bahaso Dusun	iso639-3, ethnologue
+jax	ms	Jambi Malay	Bahaso Daerah, Bahaso Dusun	iso639-3, ethnologue
 jay		Yan-nhangu		iso639-3
 jaz		Jawe		iso639-3
 jbe		Judeo-Berber		iso639-3
@@ -2955,7 +2955,7 @@ kbu		Kabutra		iso639-3
 kbv		Dera (Indonesia)		iso639-3
 kbw		Kaiep		iso639-3
 kbx		Ap Ma		iso639-3
-kby		Manga Kanuri		iso639-3
+kby	kr	Manga Kanuri		iso639-3
 kbz		Duhwa		iso639-3
 kca		Khanty		iso639-3
 kcb		Kawacha		iso639-3
@@ -3088,7 +3088,7 @@ khf		Khuen		iso639-3
 khg		Khams Tibetan		iso639-3
 khh		Kehu		iso639-3
 khj		Kuturmi		iso639-3
-khk		Halh Mongolian	Монгол хэл‎ (Mongol khel)	iso639-3, ethnologue
+khk	mn	Halh Mongolian	Монгол хэл‎ (Mongol khel)	iso639-3, ethnologue
 khl		Lusi		iso639-3
 khn		Khandesi		iso639-3
 kho		Khotanese		cldr
@@ -3220,7 +3220,7 @@ kmn		Awtuw		iso639-3
 kmo		Kwoma		iso639-3
 kmp		Gimme	Gimma	iso639-3, ethnologue
 kmq		Kwama	T’wa Kwama	iso639-3, ethnologue
-kmr		Northern Kurdish		iso639-3
+kmr	ku	Northern Kurdish		iso639-3
 kms		Kamasau		iso639-3
 kmt		Kemtuik		iso639-3
 kmu		Kanite		iso639-3
@@ -3231,11 +3231,11 @@ kmy		Koma		iso639-3
 kmz		Khorasani Turkish		iso639-3
 kna		Dera (Nigeria)		iso639-3
 knb		Lubuagan Kalinga		iso639-3
-knc		Central Kanuri	Kanuri	iso639-3, ethnologue
+knc	kr	Central Kanuri	Kanuri	iso639-3, ethnologue
 knd		Konda		iso639-3
 kne		Kankanaey		iso639-3
 knf		Mankanya		iso639-3
-kng		Koongo	Kikoongo, Koongo	iso639-3, ethnologue
+kng	kg	Koongo	Kikoongo, Koongo	iso639-3, ethnologue
 kni		Kanufi		iso639-3
 knj		Western Kanjobal	K’anjob’al	iso639-3, ethnologue
 knk		Kuranko		iso639-3
@@ -3261,7 +3261,7 @@ koe		Kacipo-Balesi	Kacipo	iso639-3, ethnologue
 kof		Kubi		iso639-3
 kog		Cogui		iso639-3
 koh		Koyo		iso639-3
-koi		Komi-Permyak		cldr
+koi	kv	Komi-Permyak		cldr
 kok		Konkani	कोंकणी	cldr
 kol		Kol (Papua New Guinea)		iso639-3
 koo		Konzo		iso639-3
@@ -3294,7 +3294,7 @@ kpr		Korafe-Yegha		iso639-3
 kps		Tehit		iso639-3
 kpt		Karata		iso639-3
 kpu		Kafoa		iso639-3
-kpv		Komi-Zyrian		iso639-3
+kpv	kv	Komi-Zyrian		iso639-3
 kpw		Kobon		iso639-3
 kpx		Mountain Koiali		iso639-3
 kpy		Koryak		iso639-3
@@ -3340,7 +3340,7 @@ krn		Sapo		iso639-3
 krp		Korop		iso639-3
 krr		Krung		iso639-3
 krs		Gbaya (Sudan)		iso639-3
-krt		Tumari Kanuri		iso639-3
+krt	kr	Tumari Kanuri		iso639-3
 kru		Kurukh		cldr
 krv		Kavet		iso639-3
 krw		Western Krahn		iso639-3
@@ -3423,7 +3423,7 @@ kux		Kukatja		iso639-3
 kuy		Kuuku-Ya'u		iso639-3
 kuz		Kunza		iso639-3
 kva		Bagvalal		iso639-3
-kvb		Kubu		iso639-3
+kvb	ms	Kubu		iso639-3
 kvc		Kove		iso639-3
 kvd		Kui (Indonesia)		iso639-3
 kve		Kalabakan		iso639-3
@@ -3439,7 +3439,7 @@ kvn		Border Kuna		iso639-3
 kvo		Dobel		iso639-3
 kvp		Kompane		iso639-3
 kvq		Geba Karen		iso639-3
-kvr		Kerinci		iso639-3
+kvr	ms	Kerinci		iso639-3
 kvt		Lahta Karen		iso639-3
 kvu		Yinbaw Karen		iso639-3
 kvv		Kola		iso639-3
@@ -3470,12 +3470,12 @@ kwu		Kwakum		iso639-3
 kwv		Sara Kaba Náà		iso639-3
 kww		Kwinti		iso639-3
 kwx		Khirwar		iso639-3
-kwy		San Salvador Kongo		iso639-3
+kwy	kg	San Salvador Kongo		iso639-3
 kwz		Kwadi		iso639-3
 kxa		Kairiru		iso639-3
 kxb		Krobu		iso639-3
 kxc		Konso	Khonso	iso639-3, ethnologue
-kxd		Brunei	Bahasa Melayu Brunei, بهاس ملايو بروني‎ (Bahasa Melayu Brunei)	iso639-3, ethnologue
+kxd	ms	Brunei	Bahasa Melayu Brunei, بهاس ملايو بروني‎ (Bahasa Melayu Brunei)	iso639-3, ethnologue
 kxf		Manumanaw Karen	Kawyaw	iso639-3, ethnologue
 kxh		Karo (Ethiopia)		iso639-3
 kxi		Keningau Murut	Keningau Murut	iso639-3, ethnologue
@@ -3593,8 +3593,8 @@ lby		Lamu-Lamu		iso639-3
 lbz		Lardil		iso639-3
 lcc		Legenyem		iso639-3
 lcd		Lola		iso639-3
-lce		Loncong		iso639-3
-lcf		Lubu		iso639-3
+lce	ms	Loncong		iso639-3
+lcf	ms	Lubu		iso639-3
 lch		Luchazi		iso639-3
 lcl		Lisela		iso639-3
 lcm		Tungag		iso639-3
@@ -3606,7 +3606,7 @@ ldb		Dũya		iso639-3
 ldd		Luri		iso639-3
 ldg		Lenyima		iso639-3
 ldh		Lamja-Dengsa-Tola		iso639-3
-ldi		Laari		iso639-3
+ldi	kg	Laari		iso639-3
 ldj		Lemoro		iso639-3
 ldk		Leelau		iso639-3
 ldl		Kaan		iso639-3
@@ -3684,7 +3684,7 @@ lir		Liberian English		iso639-3
 lis		Lisu	LI-SU‎ (Li-su), Lisu	iso639-3, ethnologue
 liu		Logorik		iso639-3
 liv		Livonian	Livõ kel	cldr, ethnologue
-liw		Col		iso639-3
+liw	ms	Col		iso639-3
 lix		Liabuku		iso639-3
 liy		Banda-Bambari	Linda	iso639-3, ethnologue
 liz		Libinza		iso639-3
@@ -3829,7 +3829,7 @@ lss		Lasi		iso639-3
 lst		Trinidad and Tobago Sign Language		iso639-3
 lsy		Mauritian Sign Language		iso639-3
 ltc		Late Middle Chinese		iso639-3
-ltg		Latgalian	Latgališu	cldr, ethnologue
+ltg	lv	Latgalian	Latgališu	cldr, ethnologue
 lth		Thur	Leb-Thur	iso639-3, ethnologue
 lti		Leti (Indonesia)		iso639-3
 ltn		Latundê		iso639-3
@@ -3860,7 +3860,7 @@ luy		Luyia	Luluhia	cldr
 luz		Southern Luri		iso639-3
 lva		Maku'a		iso639-3
 lvk		Lavukaleve		iso639-3
-lvs		Standard Latvian	Latviešu valoda, Latviski	iso639-3, ethnologue
+lvs	lv	Standard Latvian	Latviešu valoda, Latviski	iso639-3, ethnologue
 lvu		Levuka		iso639-3
 lwa		Lwalu		iso639-3
 lwe		Lewo Eleng		iso639-3
@@ -3875,7 +3875,7 @@ lww		Lewo		iso639-3
 lya		Layakha		iso639-3
 lyg		Lyngngam		iso639-3
 lyn		Luyana		iso639-3
-lzh		Literary Chinese		cldr
+lzh	zh	Literary Chinese		cldr
 lzl		Litzlitz		iso639-3
 lzn		Leinong Naga		iso639-3
 lzz		Laz	Lazuri	cldr, ethnologue
@@ -3896,7 +3896,7 @@ mat		San Francisco Matlatzinca		iso639-3
 mau		Huautla Mazatec	Enna	iso639-3, ethnologue
 mav		Sateré-Mawé		iso639-3
 maw		Mampruli	Nmampurli	iso639-3, ethnologue
-max		North Moluccan Malay	Bahasa Pasar	iso639-3, ethnologue
+max	ms	North Moluccan Malay	Bahasa Pasar	iso639-3, ethnologue
 maz		Central Mazahua	Jnatrjo	iso639-3, ethnologue
 mba		Higaonon		iso639-3
 mbb		Western Bukidnon Manobo		iso639-3
@@ -3987,7 +3987,7 @@ mek		Mekeo		iso639-3
 mel		Central Melanau		iso639-3
 mem		Mangala		iso639-3
 men		Mende	Mende, Mɛnde‎ (Mende), Mɛnde yia‎ (Mende yia)	cldr, ethnologue
-meo		Kedah Malay		iso639-3
+meo	ms	Kedah Malay		iso639-3
 mep		Miriwung		iso639-3
 meq		Merey		iso639-3
 mer		Meru	Kĩmĩrũ	cldr
@@ -3998,8 +3998,8 @@ mev		Mano	Maa	iso639-3, ethnologue
 mew		Maaka		iso639-3
 mey		Hassaniyya	Hassaniyya, حسانية‎‎‎ (Ḥassānīya)	iso639-3, ethnologue
 mez		Menominee		iso639-3
-mfa		Pattani Malay	ภาษายาวี‎ (Baso Jawi)	iso639-3, ethnologue
-mfb		Bangka		iso639-3
+mfa	ms	Pattani Malay	ภาษายาวี‎ (Baso Jawi)	iso639-3, ethnologue
+mfb	ms	Bangka		iso639-3
 mfc		Mba		iso639-3
 mfd		Mendankwe-Nkwen		iso639-3
 mfe		Morisyen	kreol morisien	cldr
@@ -4086,7 +4086,7 @@ mij		Abar		iso639-3
 mik		Mikasuki		iso639-3
 mil		Peñoles Mixtec	Tu’un savi	iso639-3, ethnologue
 mim		Alacatlatzala Mixtec	To’on Savi	iso639-3, ethnologue
-min		Minangkabau		cldr
+min	ms	Minangkabau		cldr
 mio		Pinotepa Nacional Mixtec		iso639-3
 mip		Apasco-Apoala Mixtec		iso639-3
 miq		Mískito	Mískitu	iso639-3, ethnologue
@@ -4207,7 +4207,7 @@ mnk		Mandinka		iso639-3
 mnl		Tiale		iso639-3
 mnm		Mapena		iso639-3
 mnn		Southern Mnong		iso639-3
-mnp		Min Bei Chinese		iso639-3
+mnp	zh	Min Bei Chinese		iso639-3
 mnq		Minriq		iso639-3
 mnr		Mono (USA)		iso639-3
 mns		Mansi	Ма̄ньщи	iso639-3, github
@@ -4269,7 +4269,7 @@ mqb		Mbuko		iso639-3
 mqc		Mangole		iso639-3
 mqe		Matepi		iso639-3
 mqf		Momuna		iso639-3
-mqg		Kota Bangun Kutai Malay		iso639-3
+mqg	ms	Kota Bangun Kutai Malay		iso639-3
 mqh		Tlazoyaltepec Mixtec		iso639-3
 mqi		Mariri		iso639-3
 mqj		Mamasa		iso639-3
@@ -4320,8 +4320,8 @@ msd		Yucatec Maya Sign Language		iso639-3
 mse		Musey		iso639-3
 msf		Mekwei		iso639-3
 msg		Moraid		iso639-3
-msh		Masikoro Malagasy		iso639-3
-msi		Sabah Malay	Bahasa Sabah	iso639-3, ethnologue
+msh	mg	Masikoro Malagasy		iso639-3
+msi	ms	Sabah Malay	Bahasa Sabah	iso639-3, ethnologue
 msj		Ma (Democratic Republic of Congo)		iso639-3
 msk		Mansaka		iso639-3
 msl		Molof		iso639-3
@@ -4370,7 +4370,7 @@ mud		Mednyj Aleut		iso639-3
 mue		Media Lengua		iso639-3
 mug		Musgu	Mulwi	iso639-3, ethnologue
 muh		Mündü		iso639-3
-mui		Musi		iso639-3
+mui	ms	Musi		iso639-3
 muj		Mabire		iso639-3
 muk		Mugom		iso639-3
 mul		Multiple languages		cldr
@@ -4390,7 +4390,7 @@ mva		Manam		iso639-3
 mvb		Mattole		iso639-3
 mvd		Mamboru		iso639-3
 mve		Marwari (Pakistan)		iso639-3
-mvf		Peripheral Mongolian		iso639-3
+mvf	mn	Peripheral Mongolian		iso639-3
 mvg		Yucuañe Mixtec	Tnu’u savi	iso639-3, ethnologue
 mvh		Mulgi		iso639-3
 mvi		Miyako		iso639-3
@@ -4517,7 +4517,7 @@ naj		Nalu		iso639-3
 nak		Nakanai		iso639-3
 nal		Nalik		iso639-3
 nam		Ngan'gityemerri		iso639-3
-nan		Min Nan Chinese	闽南语‎ (Minnanyu)	cldr, ethnologue
+nan	zh	Min Nan Chinese	闽南语‎ (Minnanyu)	cldr, ethnologue
 nao		Naaba		iso639-3
 nap		Neapolitan		cldr
 naq		Nama	Khoekhoegowab	cldr
@@ -4654,7 +4654,7 @@ ngz		Ngungwel		iso639-3
 nha		Nhanda		iso639-3
 nhb		Beng		iso639-3
 nhc		Tabasco Nahuatl		iso639-3
-nhd		Chiripá	Ava Guaraní	iso639-3, ethnologue
+nhd	gn	Chiripá	Ava Guaraní	iso639-3, ethnologue
 nhe		Eastern Huasteca Nahuatl		iso639-3
 nhf		Nhuwala		iso639-3
 nhg		Tetelcingo Nahuatl		iso639-3
@@ -4831,7 +4831,7 @@ npa		Nar Phu		iso639-3
 npb		Nupbikha		iso639-3
 npg		Ponyo-Gongwang Naga	Gongwang Naga, Ponyo Naga	iso639-3, ethnologue
 nph		Phom Naga		iso639-3
-npi		Nepali (individual language)	नेपाली‎ (Nepālī)	iso639-3, ethnologue
+npi	ne	Nepali (individual language)	नेपाली‎ (Nepālī)	iso639-3, ethnologue
 npl		Southeastern Puebla Nahuatl		iso639-3
 npn		Mondropolon		iso639-3
 npo		Pochuri Naga		iso639-3
@@ -5022,13 +5022,13 @@ oht		Old Hittite		iso639-3
 ohu		Old Hungarian		iso639-3
 oia		Oirata		iso639-3
 oin		Inebu One		iso639-3
-ojb		Northwestern Ojibwa		iso639-3
-ojc		Central Ojibwa		iso639-3
-ojg		Eastern Ojibwa		iso639-3
+ojb	oj	Northwestern Ojibwa		iso639-3
+ojc	oj	Central Ojibwa		iso639-3
+ojg	oj	Eastern Ojibwa		iso639-3
 ojp		Old Japanese		iso639-3
-ojs		Severn Ojibwa		iso639-3
+ojs	oj	Severn Ojibwa		iso639-3
 ojv		Ontong Java		iso639-3
-ojw		Western Ojibwa	Anishnaubemowin	iso639-3, ethnologue
+ojw	oj	Western Ojibwa	Anishnaubemowin	iso639-3, ethnologue
 oka		Okanagan	Nsyilxcen	iso639-3, ethnologue
 okb		Okobo		iso639-3
 okd		Okodia		iso639-3
@@ -5099,20 +5099,20 @@ opo		Opao		iso639-3
 opt		Opata		iso639-3
 opy		Ofayé		iso639-3
 ora		Oroha		iso639-3
-orc		Orma		iso639-3
+orc	om	Orma		iso639-3
 ore		Orejón	Maijuna	iso639-3, ethnologue
 org		Oring		iso639-3
 orh		Oroqen		iso639-3
-orn		Orang Kanaq		iso639-3
+orn	ms	Orang Kanaq		iso639-3
 oro		Orokolo		iso639-3
 orr		Oruma		iso639-3
-ors		Orang Seletar		iso639-3
+ors	ms	Orang Seletar		iso639-3
 ort		Adivasi Oriya		iso639-3
 oru		Ormuri		iso639-3
 orv		Old Russian		iso639-3
 orw		Oro Win		iso639-3
 orx		Oro		iso639-3
-ory		Odia	ଓଡ଼ିଆ‎ (Oḍiā)	iso639-3, ethnologue
+ory	or	Odia	ଓଡ଼ିଆ‎ (Oḍiā)	iso639-3, ethnologue
 orz		Ormu		iso639-3
 osa		Osage		cldr
 osc		Oscan		iso639-3
@@ -5136,7 +5136,7 @@ otr		Otoro		iso639-3
 ots		Estado de México Otomi	Hñatho	iso639-3, ethnologue
 ott		Temoaya Otomi		iso639-3
 otu		Otuke		iso639-3
-otw		Ottawa		iso639-3
+otw	oj	Ottawa		iso639-3
 otx		Texcatepec Otomi		iso639-3
 oty		Old Tamil		iso639-3
 otz		Ixtenco Otomi		iso639-3
@@ -5189,8 +5189,8 @@ pbo		Papel		iso639-3
 pbp		Badyara		iso639-3
 pbr		Pangwa		iso639-3
 pbs		Central Pame	Xi’oi	iso639-3, ethnologue
-pbt		Southern Pashto	پښتو‎‎ (Pax̌tō)	iso639-3, ethnologue
-pbu		Northern Pashto	پښتو‎ (Pashto)	iso639-3, ethnologue
+pbt	ps	Southern Pashto	پښتو‎‎ (Pax̌tō)	iso639-3, ethnologue
+pbu	ps	Northern Pashto	پښتو‎ (Pashto)	iso639-3, ethnologue
 pbv		Pnar		iso639-3
 pby		Pyu (Papua New Guinea)		iso639-3
 pca		Santa Inés Ahuatempan Popoloca	Nquivā	iso639-3, ethnologue
@@ -5226,12 +5226,12 @@ peh		Bonan		iso639-3
 pei		Chichimeca-Jonaz		iso639-3
 pej		Northern Pomo		iso639-3
 pek		Penchal		iso639-3
-pel		Pekal		iso639-3
+pel	ms	Pekal		iso639-3
 pem		Phende		iso639-3
 peo		Old Persian		cldr
 pep		Kunja		iso639-3
 peq		Southern Pomo		iso639-3
-pes		Iranian Persian	فارسی‎ (Fārsi)	iso639-3, ethnologue
+pes	fa	Iranian Persian	فارسی‎ (Fārsi)	iso639-3, ethnologue
 pev		Pémono		iso639-3
 pex		Petats		iso639-3
 pey		Petjo		iso639-3
@@ -5239,7 +5239,7 @@ pez		Eastern Penan		iso639-3
 pfa		Pááfang		iso639-3
 pfe		Peere		iso639-3
 pfl		Palatine German		cldr
-pga		Sudanese Creole Arabic	Arabi Juba	iso639-3, ethnologue
+pga	ar	Sudanese Creole Arabic	Arabi Juba	iso639-3, ethnologue
 pgd		Gāndhārī		iso639-3
 pgg		Pangwali		iso639-3
 pgi		Pagi		iso639-3
@@ -5317,7 +5317,7 @@ plp		Palpa		iso639-3
 plq		Palaic		iso639-3
 plr		Palaka Senoufo		iso639-3
 pls		San Marcos Tlacoyalco Popoloca	Ngigua	iso639-3, ethnologue
-plt		Plateau Malagasy	Malagasy, Malagasy fiteny	iso639-3, ethnologue
+plt	mg	Plateau Malagasy	Malagasy, Malagasy fiteny	iso639-3, ethnologue
 plu		Palikúr	Pa’ikwaki	iso639-3, ethnologue
 plv		Southwest Palawano		iso639-3
 plw		Brooke's Point Palawano		iso639-3
@@ -5415,7 +5415,7 @@ pro		Old Provençal		cldr
 prp		Parsi		iso639-3
 prq		Ashéninka Perené		iso639-3
 prr		Puri		iso639-3
-prs		Dari	فارسی‎ (Farsi)	iso639-3, ethnologue
+prs	fa	Dari	فارسی‎ (Farsi)	iso639-3, ethnologue
 prt		Phai		iso639-3
 pru		Puragi		iso639-3
 prw		Parawen		iso639-3
@@ -5424,7 +5424,7 @@ prz		Providencia Sign Language		iso639-3
 psa		Asue Awyu		iso639-3
 psc		Persian Sign Language		iso639-3
 psd		Plains Indian Sign Language		iso639-3
-pse		Central Malay		iso639-3
+pse	ms	Central Malay		iso639-3
 psg		Penang Sign Language		iso639-3
 psh		Southwest Pashai		iso639-3
 psi		Southeast Pashai		iso639-3
@@ -5436,7 +5436,7 @@ psp		Philippine Sign Language		iso639-3
 psq		Pasi		iso639-3
 psr		Portuguese Sign Language		iso639-3
 pss		Kaulong		iso639-3
-pst		Central Pashto		iso639-3
+pst	ps	Central Pashto		iso639-3
 psu		Sauraseni Prākrit		iso639-3
 psw		Port Sandwich		iso639-3
 psy		Piscataway		iso639-3
@@ -5491,60 +5491,60 @@ pyx		Pyu (Myanmar)		iso639-3
 pyy		Pyen		iso639-3
 pzn		Para Naga	Naga	iso639-3, ethnologue
 qua		Quapaw		iso639-3
-qub		Huallaga Huánuco Quechua		iso639-3
+qub	qu	Huallaga Huánuco Quechua		iso639-3
 quc		Kʼicheʼ	Kʼicheʼ	cldr
-qud		Calderón Highland Quichua		iso639-3
-quf		Lambayeque Quechua		iso639-3
-qug		Chimborazo Highland Quichua		cldr
-quh		South Bolivian Quechua		iso639-3
+qud	qu	Calderón Highland Quichua		iso639-3
+quf	qu	Lambayeque Quechua		iso639-3
+qug	qu	Chimborazo Highland Quichua		cldr
+quh	qu	South Bolivian Quechua		iso639-3
 qui		Quileute		iso639-3
-quk		Chachapoyas Quechua	Llakwash	iso639-3, ethnologue
-qul		North Bolivian Quechua	Quechua	iso639-3, ethnologue
+quk	qu	Chachapoyas Quechua	Llakwash	iso639-3, ethnologue
+qul	qu	North Bolivian Quechua	Quechua	iso639-3, ethnologue
 qum		Sipacapense		iso639-3
 qun		Quinault		iso639-3
-qup		Southern Pastaza Quechua	Inka	iso639-3, ethnologue
+qup	qu	Southern Pastaza Quechua	Inka	iso639-3, ethnologue
 quq		Quinqui		iso639-3
-qur		Yanahuanca Pasco Quechua		iso639-3
-qus		Santiago del Estero Quichua	Quichua	iso639-3, ethnologue
+qur	qu	Yanahuanca Pasco Quechua		iso639-3
+qus	qu	Santiago del Estero Quichua	Quichua	iso639-3, ethnologue
 quv		Sacapulteco		iso639-3
-quw		Tena Lowland Quichua		iso639-3
-qux		Yauyos Quechua		iso639-3
-quy		Ayacucho Quechua	Runasimi	iso639-3, ethnologue
-quz		Cusco Quechua	Qheswasimi, Runasimi	iso639-3, ethnologue
-qva		Ambo-Pasco Quechua		iso639-3
-qvc		Cajamarca Quechua	Kichwa	iso639-3, ethnologue
-qve		Eastern Apurímac Quechua		iso639-3
-qvh		Huamalíes-Dos de Mayo Huánuco Quechua		iso639-3
-qvi		Imbabura Highland Quichua		iso639-3
-qvj		Loja Highland Quichua		iso639-3
-qvl		Cajatambo North Lima Quechua		iso639-3
-qvm		Margos-Yarowilca-Lauricocha Quechua		iso639-3
-qvn		North Junín Quechua		iso639-3
-qvo		Napo Lowland Quechua	Runa Shimi	iso639-3, ethnologue
-qvp		Pacaraos Quechua		iso639-3
-qvs		San Martín Quechua	Llakwash Quechua	iso639-3, ethnologue
-qvw		Huaylla Wanca Quechua		iso639-3
+quw	qu	Tena Lowland Quichua		iso639-3
+qux	qu	Yauyos Quechua		iso639-3
+quy	qu	Ayacucho Quechua	Runasimi	iso639-3, ethnologue
+quz	qu	Cusco Quechua	Qheswasimi, Runasimi	iso639-3, ethnologue
+qva	qu	Ambo-Pasco Quechua		iso639-3
+qvc	qu	Cajamarca Quechua	Kichwa	iso639-3, ethnologue
+qve	qu	Eastern Apurímac Quechua		iso639-3
+qvh	qu	Huamalíes-Dos de Mayo Huánuco Quechua		iso639-3
+qvi	qu	Imbabura Highland Quichua		iso639-3
+qvj	qu	Loja Highland Quichua		iso639-3
+qvl	qu	Cajatambo North Lima Quechua		iso639-3
+qvm	qu	Margos-Yarowilca-Lauricocha Quechua		iso639-3
+qvn	qu	North Junín Quechua		iso639-3
+qvo	qu	Napo Lowland Quechua	Runa Shimi	iso639-3, ethnologue
+qvp	qu	Pacaraos Quechua		iso639-3
+qvs	qu	San Martín Quechua	Llakwash Quechua	iso639-3, ethnologue
+qvw	qu	Huaylla Wanca Quechua		iso639-3
 qvy		Queyu		iso639-3
-qvz		Northern Pastaza Quichua		iso639-3
-qwa		Corongo Ancash Quechua		iso639-3
-qwc		Classical Quechua		iso639-3
-qwh		Huaylas Ancash Quechua	Quechua	iso639-3, ethnologue
+qvz	qu	Northern Pastaza Quichua		iso639-3
+qwa	qu	Corongo Ancash Quechua		iso639-3
+qwc	qu	Classical Quechua		iso639-3
+qwh	qu	Huaylas Ancash Quechua	Quechua	iso639-3, ethnologue
 qwm		Kuman (Russia)		iso639-3
-qws		Sihuas Ancash Quechua		iso639-3
+qws	qu	Sihuas Ancash Quechua		iso639-3
 qwt		Kwalhioqua-Tlatskanai		iso639-3
-qxa		Chiquián Ancash Quechua		iso639-3
-qxc		Chincha Quechua		iso639-3
-qxh		Panao Huánuco Quechua	Panao runacuna	iso639-3, ethnologue
-qxl		Salasaca Highland Quichua		iso639-3
-qxn		Northern Conchucos Ancash Quechua	Quechua	iso639-3, ethnologue
-qxo		Southern Conchucos Ancash Quechua		iso639-3
-qxp		Puno Quechua		iso639-3
+qxa	qu	Chiquián Ancash Quechua		iso639-3
+qxc	qu	Chincha Quechua		iso639-3
+qxh	qu	Panao Huánuco Quechua	Panao runacuna	iso639-3, ethnologue
+qxl	qu	Salasaca Highland Quichua		iso639-3
+qxn	qu	Northern Conchucos Ancash Quechua	Quechua	iso639-3, ethnologue
+qxo	qu	Southern Conchucos Ancash Quechua		iso639-3
+qxp	qu	Puno Quechua		iso639-3
 qxq		Qashqa'i		iso639-3
-qxr		Cañar Highland Quichua		iso639-3
+qxr	qu	Cañar Highland Quichua		iso639-3
 qxs		Southern Qiang		iso639-3
-qxt		Santa Ana de Tusi Pasco Quechua		iso639-3
-qxu		Arequipa-La Unión Quechua		iso639-3
-qxw		Jauja Wanca Quechua		iso639-3
+qxt	qu	Santa Ana de Tusi Pasco Quechua		iso639-3
+qxu	qu	Arequipa-La Unión Quechua		iso639-3
+qxw	qu	Jauja Wanca Quechua		iso639-3
 qya		Quenya		iso639-3
 qyp		Quiripi		iso639-3
 raa		Dungmali		iso639-3
@@ -5768,16 +5768,16 @@ scw		Sha		iso639-3
 scx		Sicel		iso639-3
 sda		Toraja-Sa'dan		iso639-3
 sdb		Shabak		iso639-3
-sdc		Sassarese Sardinian		cldr
+sdc	sc	Sassarese Sardinian		cldr
 sde		Surubu		iso639-3
 sdf		Sarli		iso639-3
 sdg		Savi		iso639-3
-sdh		Southern Kurdish	کوردی خوارگ	cldr
+sdh	ku	Southern Kurdish	کوردی خوارگ	cldr
 sdj		Suundi		iso639-3
 sdk		Sos Kundi		iso639-3
 sdl		Saudi Arabian Sign Language		iso639-3
 sdm		Semandang		iso639-3
-sdn		Gallurese Sardinian		iso639-3
+sdn	sc	Gallurese Sardinian		iso639-3
 sdo		Bukar-Sadung Bidayuh		iso639-3
 sdp		Sherdukpen		iso639-3
 sdr		Oraon Sadri		iso639-3
@@ -5854,7 +5854,7 @@ shq		Sala		iso639-3
 shr		Shi		iso639-3
 shs		Shuswap		iso639-3
 sht		Shasta		iso639-3
-shu		Chadian Arabic	العربية‎ (Alearabia)	cldr, ethnologue
+shu	ar	Chadian Arabic	العربية‎ (Alearabia)	cldr, ethnologue
 shv		Shehri		iso639-3
 shw		Shwai	Cwaya	iso639-3, ethnologue
 shx		She		iso639-3
@@ -5904,7 +5904,7 @@ skc		Ma Manda		iso639-3
 skd		Southern Sierra Miwok		iso639-3
 ske		Seke (Vanuatu)		iso639-3
 skf		Sakirabiá		iso639-3
-skg		Sakalava Malagasy		iso639-3
+skg	mg	Sakalava Malagasy		iso639-3
 skh		Sikule		iso639-3
 ski		Sika		iso639-3
 skj		Seke (Nepal)		iso639-3
@@ -6027,7 +6027,7 @@ spr		Saparua		iso639-3
 sps		Saposa		iso639-3
 spt		Spiti Bhoti		iso639-3
 spu		Sapuan		iso639-3
-spv		Sambalpuri		iso639-3
+spv	or	Sambalpuri		iso639-3
 spx		South Picene		iso639-3
 spy		Sabaot		iso639-3
 sqa		Shama-Sambuga		iso639-3
@@ -6043,7 +6043,7 @@ sqt		Soqotri		iso639-3
 squ		Squamish		iso639-3
 sra		Saruga		iso639-3
 srb		Sora		iso639-3
-src		Logudorese Sardinian		iso639-3
+src	sc	Logudorese Sardinian		iso639-3
 sre		Sara		iso639-3
 srf		Nafi		iso639-3
 srg		Sulod		iso639-3
@@ -6053,7 +6053,7 @@ srk		Serudung Murut		iso639-3
 srl		Isirawa		iso639-3
 srm		Saramaccan		iso639-3
 srn		Sranan Tongo	Sranan, Sranan Tongo	cldr, ethnologue
-sro		Campidanese Sardinian		iso639-3
+sro	sc	Campidanese Sardinian		iso639-3
 srq		Sirionó		iso639-3
 srr		Serer		cldr
 srs		Tsúūt’ínà		iso639-3, github
@@ -6070,7 +6070,7 @@ ssd		Siroi		iso639-3
 sse		Balangingi	Bangingih	iso639-3, ethnologue
 ssf		Thao		iso639-3
 ssg		Seimat		iso639-3
-ssh		Shihhi Arabic		iso639-3
+ssh	ar	Shihhi Arabic		iso639-3
 ssi		Sansi		iso639-3
 ssj		Sausi		iso639-3
 ssk		Sunam		iso639-3
@@ -6137,10 +6137,10 @@ svm		Slavomolisano	Na-našu	iso639-3, ethnologue
 svs		Savosavo		iso639-3
 svx		Skalvian		iso639-3
 swb		Comorian	Maore Comorian, Shimaore	cldr, ethnologue
-swc		Congo Swahili	Kiswahili	iso639-3, ethnologue
+swc	sw	Congo Swahili	Kiswahili	iso639-3, ethnologue
 swf		Sere		iso639-3
 swg		Swabian		iso639-3
-swh		Swahili (individual language)	Kiswahili, Swahili	iso639-3, ethnologue
+swh	sw	Swahili (individual language)	Kiswahili, Swahili	iso639-3, ethnologue
 swi		Sui		iso639-3
 swj		Sira		iso639-3
 swk		Malawi Sena		iso639-3
@@ -6287,7 +6287,7 @@ tdr		Todrah		iso639-3
 tds		Doutai		iso639-3
 tdt		Tetun Dili	Lia-Tetun, Tetun Dili	iso639-3, ethnologue
 tdv		Toro		iso639-3
-tdx		Tandroy-Mahafaly Malagasy		iso639-3
+tdx	mg	Tandroy-Mahafaly Malagasy		iso639-3
 tdy		Tadyawan		iso639-3
 tea		Temiar		iso639-3
 teb		Tetete		iso639-3
@@ -6395,7 +6395,7 @@ tkb		Buksa		iso639-3
 tkd		Tukudede		iso639-3
 tke		Takwane		iso639-3
 tkf		Tukumanféd		iso639-3
-tkg		Tesaka Malagasy	Tesaka Malagasy	iso639-3, ethnologue
+tkg	mg	Tesaka Malagasy	Tesaka Malagasy	iso639-3, ethnologue
 tkl		Tokelau		cldr
 tkm		Takelma		iso639-3
 tkn		Toku-No-Shima		iso639-3
@@ -6453,7 +6453,7 @@ tms		Tima		iso639-3
 tmt		Tasmate		iso639-3
 tmu		Iau		iso639-3
 tmv		Tembo (Motembo)		iso639-3
-tmw		Temuan		iso639-3
+tmw	ms	Temuan		iso639-3
 tmy		Tami		iso639-3
 tmz		Tamanaku		iso639-3
 tna		Tacana		iso639-3
@@ -6677,7 +6677,7 @@ txs		Tonsea		iso639-3
 txt		Citak		iso639-3
 txu		Kayapó		iso639-3
 txx		Tatana	Tatana	iso639-3, ethnologue
-txy		Tanosy Malagasy		iso639-3
+txy	mg	Tanosy Malagasy		iso639-3
 tya		Tauya		iso639-3
 tye		Kyanga	Kyanga	iso639-3, ethnologue
 tyh		O'du		iso639-3
@@ -6788,7 +6788,7 @@ urf		Uradhi		iso639-3
 urg		Urigina		iso639-3
 urh		Urhobo		iso639-3
 uri		Urim		iso639-3
-urk		Urak Lawoi'		iso639-3
+urk	ms	Urak Lawoi'		iso639-3
 url		Urali		iso639-3
 urm		Urapmin		iso639-3
 urn		Uruangnirin		iso639-3
@@ -6822,8 +6822,8 @@ uvh		Uri		iso639-3
 uvl		Lote		iso639-3
 uwa		Kuku-Uwanh		iso639-3
 uya		Doko-Uyanga		iso639-3
-uzn		Northern Uzbek	O’zbek	iso639-3, ethnologue
-uzs		Southern Uzbek		iso639-3
+uzn	uz	Northern Uzbek	O’zbek	iso639-3, ethnologue
+uzs	uz	Southern Uzbek		iso639-3
 vaa		Vaagri Booli		iso639-3
 vae		Vale		iso639-3
 vaf		Vafsi		iso639-3
@@ -6864,12 +6864,12 @@ viv		Iduna		iso639-3
 vka		Kariyarra		iso639-3
 vki		Ija-Zuba		iso639-3
 vkj		Kujarge		iso639-3
-vkk		Kaur		iso639-3
+vkk	ms	Kaur		iso639-3
 vkl		Kulisusu		iso639-3
 vkm		Kamakan		iso639-3
 vko		Kodeoha		iso639-3
 vkp		Korlai Creole Portuguese		iso639-3
-vkt		Tenggarong Kutai Malay		iso639-3
+vkt	ms	Tenggarong Kutai Malay		iso639-3
 vku		Kurrama		iso639-3
 vlp		Valpei		iso639-3
 vls		West Flemish		cldr
@@ -6902,7 +6902,7 @@ vnp		Vunapu		iso639-3
 vor		Voro		iso639-3
 vot		Votic		cldr
 vra		Vera'a		iso639-3
-vro		Võro	Võro kiil	cldr, ethnologue
+vro	et	Võro	Võro kiil	cldr, ethnologue
 vrs		Varisi		iso639-3
 vrt		Burmbar		iso639-3
 vsi		Moldova Sign Language		iso639-3
@@ -7118,7 +7118,7 @@ wum		Wumbvu		iso639-3
 wun		Bungu		iso639-3
 wur		Wurrugu		iso639-3
 wut		Wutung		iso639-3
-wuu		Wu Chinese		cldr
+wuu	zh	Wu Chinese		cldr
 wuv		Wuvulu-Aua		iso639-3
 wux		Wulna		iso639-3
 wuy		Wauyai		iso639-3
@@ -7280,7 +7280,7 @@ xmh		Kuku-Muminh		iso639-3
 xmj		Majera		iso639-3
 xmk		Ancient Macedonian		iso639-3
 xml		Malaysian Sign Language		iso639-3
-xmm		Manado Malay	Bahasa Manado	iso639-3, ethnologue
+xmm	ms	Manado Malay	Bahasa Manado	iso639-3, ethnologue
 xmn		Manichaean Middle Persian		iso639-3
 xmo		Morerebi		iso639-3
 xmp		Kuku-Mu'inh		iso639-3
@@ -7289,8 +7289,8 @@ xmr		Meroitic		iso639-3
 xms		Moroccan Sign Language		iso639-3
 xmt		Matbat		iso639-3
 xmu		Kamu		iso639-3
-xmv		Antankarana Malagasy		iso639-3
-xmw		Tsimihety Malagasy		iso639-3
+xmv	mg	Antankarana Malagasy		iso639-3
+xmw	mg	Tsimihety Malagasy		iso639-3
 xmx		Maden		iso639-3
 xmy		Mayaguduna		iso639-3
 xmz		Mori Bawah		iso639-3
@@ -7481,7 +7481,7 @@ ycl		Lolopo		iso639-3
 ycn		Yucuna	Yucuna	iso639-3, ethnologue
 ycp		Chepya		iso639-3
 yda		Yanda		iso639-3
-ydd		Eastern Yiddish	יידיש‎ (Yiddish)	iso639-3, ethnologue
+ydd	yi	Eastern Yiddish	יידיש‎ (Yiddish)	iso639-3, ethnologue
 yde		Yangum Dey		iso639-3
 ydg		Yidgha		iso639-3
 ydk		Yoidik		iso639-3
@@ -7513,7 +7513,7 @@ yhs		Yan-nhaŋu Sign Language		iso639-3
 yia		Yinggarda		iso639-3
 yif		Ache		iso639-3
 yig		Wusa Nasu		iso639-3
-yih		Western Yiddish		iso639-3
+yih	yi	Western Yiddish		iso639-3
 yii		Yidiny		iso639-3
 yij		Yindjibarndi		iso639-3
 yik		Dongshanba Lalo		iso639-3
@@ -7631,7 +7631,7 @@ yua		Yucateco	Maaya t’aan	iso639-3, ethnologue
 yub		Yugambal		iso639-3
 yuc		Yuchi		iso639-3
 yud		Judeo-Tripolitanian Arabic		iso639-3
-yue		Cantonese	粵語	cldr
+yue	zh	Cantonese	粵語	cldr
 yuf		Havasupai-Walapai-Yavapai		iso639-3
 yug		Yug		iso639-3
 yui		Yurutí	Wajiaraye	iso639-3, ethnologue
@@ -7701,22 +7701,22 @@ zbl		Blissymbols		cldr
 zbt		Batui		iso639-3
 zbw		West Berawan		iso639-3
 zca		Coatecas Altas Zapotec		iso639-3
-zch		Central Hongshuihe Zhuang		iso639-3
+zch	za	Central Hongshuihe Zhuang		iso639-3
 zdj		Ngazidja Comorian		iso639-3
 zea		Zeelandic		cldr
 zeg		Zenag		iso639-3
-zeh		Eastern Hongshuihe Zhuang		iso639-3
+zeh	za	Eastern Hongshuihe Zhuang		iso639-3
 zen		Zenaga		cldr
 zga		Kinga	Bakinga	iso639-3, ethnologue
-zgb		Guibei Zhuang		iso639-3
+zgb	za	Guibei Zhuang		iso639-3
 zgh		Standard Moroccan Tamazight	ⵜⴰⵎⴰⵣⵉⵖⵜ	cldr
-zgm		Minz Zhuang		iso639-3
-zgn		Guibian Zhuang		iso639-3
+zgm	za	Minz Zhuang		iso639-3
+zgn	za	Guibian Zhuang		iso639-3
 zgr		Magori		iso639-3
 zhb		Zhaba		iso639-3
-zhd		Dai Zhuang		iso639-3
+zhd	za	Dai Zhuang		iso639-3
 zhi		Zhire		iso639-3
-zhn		Nong Zhuang	Tei Nong	iso639-3, ethnologue
+zhn	za	Nong Zhuang	Tei Nong	iso639-3, ethnologue
 zhw		Zhoa		iso639-3
 zia		Zia		iso639-3
 zib		Zimbabwe Sign Language		iso639-3
@@ -7741,10 +7741,10 @@ zkt		Kitan		iso639-3
 zku		Kaurna		iso639-3
 zkv		Krevinian		iso639-3
 zkz		Khazar		iso639-3
-zlj		Liujiang Zhuang		iso639-3
-zlm		Malay (individual language)	Bahasa Melayu, ملايو‎ (Melayu)	iso639-3, ethnologue
-zln		Lianshan Zhuang		iso639-3
-zlq		Liuqian Zhuang		iso639-3
+zlj	za	Liujiang Zhuang		iso639-3
+zlm	ms	Malay (individual language)	Bahasa Melayu, ملايو‎ (Melayu)	iso639-3, ethnologue
+zln	za	Lianshan Zhuang		iso639-3
+zlq	za	Liuqian Zhuang		iso639-3
 zma		Manda (Australia)		iso639-3
 zmb		Zimba		iso639-3
 zmc		Margany		iso639-3
@@ -7753,7 +7753,7 @@ zme		Mangerr		iso639-3
 zmf		Mfinu		iso639-3
 zmg		Marti Ke		iso639-3
 zmh		Makolkol		iso639-3
-zmi		Negeri Sembilan Malay		iso639-3
+zmi	ms	Negeri Sembilan Malay		iso639-3
 zmj		Maridjabin		iso639-3
 zmk		Mandandanyi		iso639-3
 zml		Madngele		iso639-3
@@ -7809,7 +7809,7 @@ zpw		Zaniza Zapotec		iso639-3
 zpx		San Baltazar Loxicha Zapotec		iso639-3
 zpy		Mazaltepec Zapotec		iso639-3
 zpz		Texmelucan Zapotec		iso639-3
-zqe		Qiubei Zhuang		iso639-3
+zqe	za	Qiubei Zhuang		iso639-3
 zra		Kara (Korea)		iso639-3
 zrg		Mirgan		iso639-3
 zrn		Zerenkel		iso639-3
@@ -7819,7 +7819,7 @@ zrs		Mairasi		iso639-3
 zsa		Sarasira		iso639-3
 zsk		Kaskean		iso639-3
 zsl		Zambian Sign Language		iso639-3
-zsm		Standard Malay	Bahasa Malaysia	iso639-3, ethnologue
+zsm	ms	Standard Malay	Bahasa Malaysia	iso639-3, ethnologue
 zsr		Southern Rincon Zapotec		iso639-3
 zsu		Sukurum		iso639-3
 zte		Elotepec Zapotec		iso639-3
@@ -7836,15 +7836,15 @@ ztx		Zaachila Zapotec		iso639-3
 zty		Yatee Zapotec		iso639-3
 zua		Zeem		iso639-3
 zuh		Tokano		iso639-3
-zyg		Yang Zhuang	壮语徳靖‎ (Deijing Zhuang)	iso639-3, ethnologue
+zyg	za	Yang Zhuang	壮语徳靖‎ (Deijing Zhuang)	iso639-3, ethnologue
 zum		Kumzari		iso639-3
 zun		Zuni	Shiwi’ma	cldr, ethnologue
 zuy		Zumaya		iso639-3
 zwa		Zay		iso639-3
 zxx		No linguistic content		cldr
-zyb		Yongbei Zhuang		iso639-3
-zyj		Youjiang Zhuang		iso639-3
-zyn		Yongnan Zhuang		iso639-3
+zyb	za	Yongbei Zhuang		iso639-3
+zyj	za	Youjiang Zhuang		iso639-3
+zyn	za	Yongnan Zhuang		iso639-3
 zyp		Zyphe Chin		iso639-3
 zza		Zaza		cldr
-zzj		Zuojiang Zhuang		iso639-3
+zzj	za	Zuojiang Zhuang		iso639-3


### PR DESCRIPTION
This PR updates the ISO 639 and autonym table using RFC 5646. RFC 5646 defines a standard format for identifying languages and regional variants. This allows for more accurate and universal labeling of languages and avoids confusion or inconsistency. In this PR, I added new language codes and autonyms, and corrected some errors and outdated data in the existing table.