### PR TITLE
feat: `async-graphql` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,17 @@ phf = "0.11"
 optional = true
 version = "1.0"
 
+[dependencies.async-graphql]
+optional = true
+version = "6.0"
+
 [features]
 default = ["english_names"]
 english_names = []
 lowercase_names = []
 local_names = []
 list_languages = []
+async-graphql = ["dep:async-graphql"]
 
 [dev-dependencies]
 phf_codegen = "0.11"

--- a/src/isotable.rs
+++ b/src/isotable.rs
@@ -63285,6 +63285,7 @@ pub(crate) const OVERVIEW: [LanguageData; 7910] = [
     },
 ];
 #[derive(Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]
 pub enum Language {
     #[doc(hidden)]
     Aaa = 0,

--- a/tests/generate_static_table.rs
+++ b/tests/generate_static_table.rs
@@ -182,6 +182,10 @@ fn generated_code_table_if_outdated() {
         "#[derive(Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]"
     )
     .unwrap();
+
+    writeln!(
+        &mut new_code,
+r###"#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]"###).unwrap();
     writeln!(&mut new_code, "pub enum Language {{").unwrap();
     for (num, lang) in codes.iter().enumerate() {
         writeln!(&mut new_code, "    #[doc(hidden)]").unwrap();


### PR DESCRIPTION
I would suggest to also add a documentation line to each language which states the language in full name, for example: 
```rs
/// Dutch (Nederlands)
Nld
```

As these are added as documentation by async-graphql.

Without these the documentation provided by GraphQL is kind of stale:

![image](https://github.com/humenda/isolang-rs/assets/7997154/294253a6-e50b-4be3-bedf-4f11c993639c)
