### PR TITLE
Add support for iso-639-2t/b

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Introduction
 
 When dealing with different language inputs and APIs, different standards are used to identify
 a language. Converting between these in an automated way can be tedious. This crate provides an
-enum which supports conversion from 639-1 and 639-3 and also into these formats, as well as
-into English names or autonyms (local names).
+enum which enables conversion between the standards 639-1, 639-2t, 639-2b and 639-3, as well as conversion
+into English and local names (autonyms).
 
 This crate contains the ISO 639 table in statically embedded tables. This
 increases binary size, but allows for very efficient look-up if performance
@@ -39,6 +39,8 @@ Example
 use isolang::Language;
 
 assert_eq!(Language::from_639_1("de").unwrap().to_name(), "German");
+assert_eq!(Language::from_639_2b("fre").unwrap().to_name(), "French");
+assert_eq!(Language::from_639_2t("fra").unwrap().to_name(), "French");
 assert_eq!(Language::from_639_3("spa").unwrap().to_639_1(), Some("es"));
 // undefined language (ISO code und)
 assert_eq!(Language::default(), Language::Und);
@@ -58,8 +60,7 @@ assert_eq!(Language::from_str("español").unwrap().to_name(), "Spanish");
 Supported Cargo Features
 -------------------------
 
-
-Please take a look at the commented [Cargo.toml)(Cargo.toml) file for a
+Please take a look at the commented [Cargo.toml](Cargo.toml) file for a
 up-to-date list of supported features.
 
 Serde support

--- a/src/isotable.rs
+++ b/src/isotable.rs
@@ -96861,3 +96861,35 @@ pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {
         _ => code,
     }
 }
+pub(crate) fn iso_639_2t_to_3(code: &str) -> &str {
+    #[allow(clippy::match_single_binding)]
+    match code {
+        _ => code,
+    }
+}
+pub(crate) fn iso_639_2b_to_3(code: &str) -> &str {
+    #[allow(clippy::match_single_binding)]
+    match code {
+        "tib" => "bod",
+        "cze" => "ces",
+        "wel" => "cym",
+        "ger" => "deu",
+        "gre" => "ell",
+        "baq" => "eus",
+        "per" => "fas",
+        "fre" => "fra",
+        "arm" => "hye",
+        "ice" => "isl",
+        "geo" => "kat",
+        "mac" => "mkd",
+        "mao" => "mri",
+        "may" => "msa",
+        "bur" => "mya",
+        "dut" => "nld",
+        "rum" => "ron",
+        "slo" => "slk",
+        "alb" => "sqi",
+        "chi" => "zho",
+        _ => code,
+    }
+}

--- a/src/isotable.rs
+++ b/src/isotable.rs
@@ -96829,14 +96829,7 @@ pub(crate) const THREE_TO_THREE: phf::Map<&str, u16> = ::phf::Map {
         ("xjt", Language::Xjt as u16),
     ],
 };
-pub(crate) fn iso_639_3_to_2t(code: &str) -> &str {
-    #[allow(clippy::match_single_binding)]
-    match code {
-        _ => code,
-    }
-}
 pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {
-    #[allow(clippy::match_single_binding)]
     match code {
         "bod" => "tib",
         "ces" => "cze",
@@ -96858,12 +96851,6 @@ pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {
         "slk" => "slo",
         "sqi" => "alb",
         "zho" => "chi",
-        _ => code,
-    }
-}
-pub(crate) fn iso_639_2t_to_3(code: &str) -> &str {
-    #[allow(clippy::match_single_binding)]
-    match code {
         _ => code,
     }
 }

--- a/src/isotable.rs
+++ b/src/isotable.rs
@@ -96829,3 +96829,35 @@ pub(crate) const THREE_TO_THREE: phf::Map<&str, u16> = ::phf::Map {
         ("xjt", Language::Xjt as u16),
     ],
 };
+pub(crate) fn iso_639_3_to_2t(code: &str) -> &str {
+    #[allow(clippy::match_single_binding)]
+    match code {
+        _ => code,
+    }
+}
+pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {
+    #[allow(clippy::match_single_binding)]
+    match code {
+        "bod" => "tib",
+        "ces" => "cze",
+        "cym" => "wel",
+        "deu" => "ger",
+        "ell" => "gre",
+        "eus" => "baq",
+        "fas" => "per",
+        "fra" => "fre",
+        "hye" => "arm",
+        "isl" => "ice",
+        "kat" => "geo",
+        "mkd" => "mac",
+        "mri" => "mao",
+        "msa" => "may",
+        "mya" => "bur",
+        "nld" => "dut",
+        "ron" => "rum",
+        "slk" => "slo",
+        "sqi" => "alb",
+        "zho" => "chi",
+        _ => code,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,7 @@ struct LanguageData {
 mod isotable;
 pub use isotable::Language;
 use isotable::{
-    iso_639_2b_to_3, iso_639_2t_to_3, iso_639_3_to_2b, iso_639_3_to_2t,
-    OVERVIEW, THREE_TO_THREE, TWO_TO_THREE,
+    iso_639_2b_to_3, iso_639_3_to_2b, OVERVIEW, THREE_TO_THREE, TWO_TO_THREE,
 };
 
 /// Get an iterator of all languages.
@@ -145,7 +144,7 @@ impl Language {
     /// assert_eq!(Language::Deu.to_639_2t(), "deu");
     /// ```
     pub fn to_639_2t(&self) -> &'static str {
-        iso_639_3_to_2t(self.to_639_3())
+        self.to_639_3()
     }
 
     /// Create two-letter ISO 639-1 representation of the language.
@@ -365,7 +364,8 @@ impl Language {
     /// assert!(Language::from_639_2t("deu").is_some());
     /// ```
     pub fn from_639_2t(code: &str) -> Option<Language> {
-        Self::from_639_3(iso_639_2t_to_3(code))
+        // ISO 639-3 codes are backwards compatible with ISO 639-2t codes
+        Self::from_639_3(code)
     }
 
     /// Create a Language instance rom a ISO 639-2b code.
@@ -488,7 +488,7 @@ impl FromStr for Language {
     fn from_str(s: &str) -> Result<Self, ParseLanguageError> {
         match Language::from_639_3(s)
             .or_else(|| Language::from_639_1(s))
-            .or_else(|| Language::from_639_2t(s))
+            // .or_else(|| Language::from_639_2t(s)) // ISO 639-3 codes are backwards compatible with ISO 639-2t codes, so this is unnecessary
             .or_else(|| Language::from_639_2b(s))
         {
             Some(l) => Ok(l),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,9 @@ struct LanguageData {
 #[rustfmt::skip]
 mod isotable;
 pub use isotable::Language;
-use isotable::{OVERVIEW, THREE_TO_THREE, TWO_TO_THREE};
+use isotable::{
+    iso_639_3_to_2b, iso_639_3_to_2t, OVERVIEW, THREE_TO_THREE, TWO_TO_THREE,
+};
 
 /// Get an iterator of all languages.
 ///
@@ -113,6 +115,36 @@ impl Language {
     pub fn to_639_3(&self) -> &'static str {
         // SAFETY: The ISO 639 table has been written to the binary with UTF-8 encoding, hence reading it without checks is safe.
         unsafe { str::from_utf8_unchecked(&OVERVIEW[*self as usize].code_3) }
+    }
+
+    /// Create string representation of this Language as a ISO 639-2b code.
+    ///
+    /// This method will return the ISO 639-2b code, which consists of three letters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use isolang::Language;
+    ///
+    /// assert_eq!(Language::Deu.to_639_2b(), "ger");
+    /// ```
+    pub fn to_639_2b(&self) -> &'static str {
+        iso_639_3_to_2b(self.to_639_3())
+    }
+
+    /// Create string representation of this Language as a ISO 639-2t code.
+    ///
+    /// This method will return the ISO 639-2t code, which consists of three letters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use isolang::Language;
+    ///
+    /// assert_eq!(Language::Deu.to_639_2t(), "ger");
+    /// ```
+    pub fn to_639_2t(&self) -> &'static str {
+        iso_639_3_to_2t(self.to_639_3())
     }
 
     /// Create two-letter ISO 639-1 representation of the language.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,9 +362,7 @@ impl Language {
     ///
     /// ```
     /// use isolang::Language;
-    ///
-    /// assert!(Language::from_639_3("ger").is_some());
-    /// assert!(Language::from_639_1("…").is_none());
+    /// assert!(Language::from_639_2t("deu").is_some());
     /// ```
     pub fn from_639_2t(code: &str) -> Option<Language> {
         Self::from_639_3(iso_639_2t_to_3(code))
@@ -379,9 +377,7 @@ impl Language {
     ///
     /// ```
     /// use isolang::Language;
-    ///
-    /// assert!(Language::from_639_3("dan").is_some());
-    /// assert!(Language::from_639_1("…").is_none());
+    /// assert!(Language::from_639_2b("ger").is_some());
     /// ```
     pub fn from_639_2b(code: &str) -> Option<Language> {
         Self::from_639_3(iso_639_2b_to_3(code))

--- a/tests/generate_static_table.rs
+++ b/tests/generate_static_table.rs
@@ -37,7 +37,7 @@ fn format_code(code: &str) -> String {
 struct LangCode<'a> {
     code_3: &'a str,
     code_2b: Option<&'a str>,
-    code_2t: Option<&'a str>,
+    _code_2t: Option<&'a str>,
     code_1: Option<&'a str>,
     name_en: &'a str,
     autonym: Option<&'a str>,
@@ -84,7 +84,7 @@ fn read_iso_table<'a>(
                 "" => None,
                 s => Some(s),
             };
-            let code_2t = match cols.next().unwrap() {
+            let _code_2t = match cols.next().unwrap() {
                 "" => None,
                 s => Some(s),
             };
@@ -97,7 +97,14 @@ fn read_iso_table<'a>(
             // split language string into name and comment, if required
             let mut parts = cols.nth(2).unwrap().split('(');
             let name_en = parts.next().unwrap().trim_end();
-            LangCode { code_3, code_2b, code_2t, code_1, name_en, autonym }
+            LangCode {
+                code_3,
+                code_2b,
+                _code_2t,
+                code_1,
+                name_en,
+                autonym,
+            }
         })
         .collect()
 }
@@ -163,32 +170,10 @@ fn write_three_letter_to_enum(out: &mut String, codes: &[LangCode]) {
     writeln!(out, "{};", map.build()).unwrap();
 }
 
-fn write_iso_639_3_to_2_conversions(out: &mut String, codes: &[LangCode]) {
-    // 3 -> 2t
-    writeln!(out, "pub(crate) fn iso_639_3_to_2t(code: &str) -> &str {{")
-        .unwrap();
-    writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
-    writeln!(out, "    match code {{").unwrap();
-    for lang in codes.iter() {
-        if let Some(code_2t) = lang.code_2t {
-            if code_2t != lang.code_3 {
-                writeln!(
-                    out,
-                    "        \"{}\" => \"{}\",",
-                    lang.code_3, code_2t
-                )
-                .unwrap();
-            }
-        }
-    }
-    writeln!(out, "        _ => code,").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "}}").unwrap();
-
+fn write_iso_639_3_to_2b_conversions(out: &mut String, codes: &[LangCode]) {
     // 3 -> 2b
     writeln!(out, "pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {{")
         .unwrap();
-    writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
     writeln!(out, "    match code {{").unwrap();
     for lang in codes.iter() {
         if let Some(code_2b) = lang.code_2b {
@@ -197,27 +182,6 @@ fn write_iso_639_3_to_2_conversions(out: &mut String, codes: &[LangCode]) {
                     out,
                     "        \"{}\" => \"{}\",",
                     lang.code_3, code_2b
-                )
-                .unwrap();
-            }
-        }
-    }
-    writeln!(out, "        _ => code,").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "}}").unwrap();
-
-    // 2t -> 3
-    writeln!(out, "pub(crate) fn iso_639_2t_to_3(code: &str) -> &str {{")
-        .unwrap();
-    writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
-    writeln!(out, "    match code {{").unwrap();
-    for lang in codes.iter() {
-        if let Some(code_2t) = lang.code_2t {
-            if code_2t != lang.code_3 {
-                writeln!(
-                    out,
-                    "        \"{}\" => \"{}\",",
-                    code_2t, lang.code_3
                 )
                 .unwrap();
             }
@@ -317,7 +281,7 @@ r###"#[cfg_attr(feature = "async-graphql", derive(async_graphql::Enum))]"###).un
     write_three_letter_to_enum(&mut new_code, &codes);
 
     // write conversion function from 639-3 to 639-2t/b
-    write_iso_639_3_to_2_conversions(&mut new_code, &codes);
+    write_iso_639_3_to_2b_conversions(&mut new_code, &codes);
 
     // compare old to new -- format new code first
     let new_code = format_code(&new_code);

--- a/tests/generate_static_table.rs
+++ b/tests/generate_static_table.rs
@@ -36,8 +36,8 @@ fn format_code(code: &str) -> String {
 /// Language data as extracted from `iso-639-3.tsv` and `iso-639-autonyms.tsv`.
 struct LangCode<'a> {
     code_3: &'a str,
-    code_2b: &'a str,
-    code_2t: &'a str,
+    code_2b: Option<&'a str>,
+    code_2t: Option<&'a str>,
     code_1: Option<&'a str>,
     name_en: &'a str,
     autonym: Option<&'a str>,
@@ -81,12 +81,12 @@ fn read_iso_table<'a>(
             let mut cols = line.split('\t');
             let code_3 = cols.next().unwrap();
             let code_2b = match cols.next().unwrap() {
-                "" => code_3,
-                s => s,
+                "" => None,
+                s => Some(s),
             };
             let code_2t = match cols.next().unwrap() {
-                "" => code_3,
-                s => s,
+                "" => None,
+                s => Some(s),
             };
             let code_1 = cols.next().filter(|s| s.len() == 2);
             let autonym = match autonyms_table.get(code_3) {
@@ -164,38 +164,84 @@ fn write_three_letter_to_enum(out: &mut String, codes: &[LangCode]) {
 }
 
 fn write_iso_639_3_to_2_conversions(out: &mut String, codes: &[LangCode]) {
-    // 2t
+    // 3 -> 2t
     writeln!(out, "pub(crate) fn iso_639_3_to_2t(code: &str) -> &str {{")
         .unwrap();
     writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
     writeln!(out, "    match code {{").unwrap();
     for lang in codes.iter() {
-        if lang.code_3 != lang.code_2t {
-            writeln!(
-                out,
-                "        \"{}\" => \"{}\",",
-                lang.code_3, lang.code_2t
-            )
-            .unwrap();
+        if let Some(code_2t) = lang.code_2t {
+            if code_2t != lang.code_3 {
+                writeln!(
+                    out,
+                    "        \"{}\" => \"{}\",",
+                    lang.code_3, code_2t
+                )
+                .unwrap();
+            }
         }
     }
     writeln!(out, "        _ => code,").unwrap();
     writeln!(out, "    }}").unwrap();
     writeln!(out, "}}").unwrap();
 
-    // 2b
+    // 3 -> 2b
     writeln!(out, "pub(crate) fn iso_639_3_to_2b(code: &str) -> &str {{")
         .unwrap();
     writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
     writeln!(out, "    match code {{").unwrap();
     for lang in codes.iter() {
-        if lang.code_3 != lang.code_2b {
-            writeln!(
-                out,
-                "        \"{}\" => \"{}\",",
-                lang.code_3, lang.code_2b
-            )
-            .unwrap();
+        if let Some(code_2b) = lang.code_2b {
+            if code_2b != lang.code_3 {
+                writeln!(
+                    out,
+                    "        \"{}\" => \"{}\",",
+                    lang.code_3, code_2b
+                )
+                .unwrap();
+            }
+        }
+    }
+    writeln!(out, "        _ => code,").unwrap();
+    writeln!(out, "    }}").unwrap();
+    writeln!(out, "}}").unwrap();
+
+    // 2t -> 3
+    writeln!(out, "pub(crate) fn iso_639_2t_to_3(code: &str) -> &str {{")
+        .unwrap();
+    writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
+    writeln!(out, "    match code {{").unwrap();
+    for lang in codes.iter() {
+        if let Some(code_2t) = lang.code_2t {
+            if code_2t != lang.code_3 {
+                writeln!(
+                    out,
+                    "        \"{}\" => \"{}\",",
+                    code_2t, lang.code_3
+                )
+                .unwrap();
+            }
+        }
+    }
+    writeln!(out, "        _ => code,").unwrap();
+    writeln!(out, "    }}").unwrap();
+    writeln!(out, "}}").unwrap();
+
+    // 2b -> 3
+    writeln!(out, "pub(crate) fn iso_639_2b_to_3(code: &str) -> &str {{")
+        .unwrap();
+    writeln!(out, "    #[allow(clippy::match_single_binding)]").unwrap();
+    writeln!(out, "    match code {{").unwrap();
+    for lang in codes.iter() {
+        if let Some(code_2b) = lang.code_2b {
+            if code_2b != lang.code_3 {
+                writeln!(
+                    out,
+                    "        \"{}\" => \"{}\",",
+                    code_2b, lang.code_3
+                )
+                .unwrap();
+            }
         }
     }
     writeln!(out, "        _ => code,").unwrap();


### PR DESCRIPTION
Adds support for is iso-639-2t and iso-639-2b

This implementation avoids adding extra tables for 2t/b, with the tradeoff, that the functions for 639-2 will incorrectly accept 639-3 codes, and will also generate 639-3 codes if a `Language` doesn't have a code in that standard.

So for example, even though there is no 639-2 code for "Ghotuo" (iso 639-3 code "aaa") the following works:
```
assert_eq(Language::Aaa.to_639_2t(), "aaa"); // Works!
assert_eq(Language::from_639_2b("aaa"), Language::Aaa); // Works!
```

I can rewrite it to use phf tables if this behavior is a problem.