### PR TITLE
Correct name of Tongan

### DIFF
--- a/iso-639-3.tab
+++ b/iso-639-3.tab
@@ -6503,7 +6503,7 @@ toj				I	L	Tojolabal
 tok				I	C	Toki Pona	
 tol				I	E	Tolowa	
 tom				I	L	Tombulu	
-ton	ton	ton	to	I	L	Tonga (Tonga Islands)	
+ton	ton	ton	to	I	L	Tongan (Tonga Islands)	
 too				I	L	Xicotepec De Juárez Totonac	
 top				I	L	Papantla Totonac	
 toq				I	L	Toposa	

--- a/src/isotable.rs
+++ b/src/isotable.rs
@@ -52039,7 +52039,7 @@ pub(crate) const OVERVIEW: [LanguageData; 7916] = [
         code_3: [116, 111, 110],
         code_1: Some([116, 111]),
         #[cfg(feature = "english_names")]
-        name_en: "Tonga",
+        name_en: "Tongan",
         #[cfg(feature = "local_names")]
         autonym: Some("lea fakatonga"),
     },


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/Tongan_language